### PR TITLE
fix(rules): scope AP1, and document autonomous pentesting as an option

### DIFF
--- a/.agent/BOOTSTRAP.md
+++ b/.agent/BOOTSTRAP.md
@@ -387,7 +387,7 @@ Dependendo da stack (pergunta 5), ajustar seccoes especificas:
 
 ### 2.8 Ficheiros de regras/contexto adicionais e lingua
 
-- **`.agent/rules/anti-patterns.md`**: apagar o exemplo `AP1` comentado (e ilustrativo); manter o cabecalho, o preambulo "como fazer crescer" e a linha "sem anti-padroes registados ainda".
+- **`.agent/rules/anti-patterns.md`**: apagar o exemplo comentado (e ilustrativo). A entrada **AP1** que vem preenchida e real e herdada do template — aplica-se a qualquer projeto que escreva testes de verificadores. Manter se o projeto tiver guards/scripts proprios; substituir pela primeira entrada tua se nao tiver.
 - **`.agent/rules/sync-docs.md`**, **`.agent/context/backlog-archive.md`**, **`decisions-archive.md`**, **`walkthrough-archive.md`**: sem conteudo a gerar — o sweep de placeholders (2.1) trata dos titulos. Nao importar `sync-docs.md` nem os `*-archive.md` em `CLAUDE.md`/`GEMINI.md`.
 - **Lingua dos docs**: os docs de `.agent/` e `src/docs/` estao em PT-PT. Se a lingua da equipa/UI (pergunta 6) **nao** for PT-PT, **traduzir** rules, workflows e ficheiros de contexto para essa lingua (o codigo, variaveis e nomes de ficheiros permanecem em ingles).
 

--- a/.agent/rules/anti-patterns.md
+++ b/.agent/rules/anti-patterns.md
@@ -23,22 +23,23 @@
 
 -->
 
-## AP1 — Teste cuja assercao e satisfeita por outro guard
+## AP1 — Teste cuja assercao e satisfeita por outra verificacao
 
-- **Origem**: quatro rondas consecutivas de review a este repo (a mesma classe, quatro vezes).
-- **Anti-padrao**: afirmar `out.includes("<texto>")` sobre o output INTEIRO de um verificador,
-  com uma mutacao que quebra mais do que o alvo do teste. Tipico: escrever `CLAUDE.md` sem
-  escrever `GEMINI.md`, o que dispara sempre o guard de paridade. O teste fica verde porque
-  OUTRO guard avisou, e neutralizar o guard sob teste passa despercebido. A variante mais
-  subtil: `includes` nao distingue `WARN` de `NOTE`, logo despromover um aviso a nota mantem
-  o teste verde e desliga o gate.
-- **Correto**: afirmar contra as linhas do NIVEL certo (so as `WARN`), e mutar apenas o input
-  do guard sob teste — ou normalizar tudo o resto primeiro. Para verificadores, medir
-  **cobertura de mutacao**: sabotar cada sitio de aviso, um a um, e exigir que a suite fique
-  vermelha em cada um. Foi essa varredura que revelou 7 ramos sem cobertura que 109 testes
-  verdes escondiam.
-- **Detecao em review**: `grep -n 'writeF(dir, "CLAUDE.md"' .agent/scripts/test-guards.mjs` —
-  cada ocorrencia tem de escrever tambem o `GEMINI.md`, ou declarar `excludes: ["DIVERGEM"]`.
-  E `grep -c 'includes:' .agent/scripts/test-guards.mjs` nao pode crescer sem que a varredura
-  de mutacao (`node .agent/scripts/test-guards.mjs` apos sabotar cada `warn(`) continue a
-  apanhar 100% dos sitios.
+- **Origem**: cinco rondas de review a este template, sempre a mesma classe.
+- **Anti-padrao**: afirmar `output.includes("<texto>")` sobre o output INTEIRO de um
+  verificador, com uma mutacao que quebra mais do que o alvo do teste. O teste fica verde
+  porque OUTRA verificacao falhou, e neutralizar a que esta sob teste passa despercebido.
+  Variante: o `includes` nao distingue niveis, logo despromover um erro a aviso mantem o
+  teste verde e desliga o gate.
+- **Correto**: afirmar contra as linhas do nivel certo, e mutar so o input do alvo. Para
+  verificadores, medir **cobertura de mutacao**: sabotar cada sitio de erro, um a um, e
+  exigir que a suite fique vermelha em cada um.
+- **Detecao em review**: sabotar e contar.
+  `grep -c 'includes:' <ficheiro-de-testes>` nao pode crescer sem que a varredura de
+  mutacao continue a apanhar 100% dos sitios. Neste repo:
+  `node .agent/scripts/test-guards.mjs` apos trocar cada `warn(` por `note(` em
+  `check-doc-versions.mjs` — 47 sitios, todos tem de ficar vermelhos.
+
+> Esta entrada vem do template. Aplica-se a qualquer projeto que escreva testes de
+> verificadores; se o teu projeto nao tiver nenhum, podes substitui-la pela primeira que
+> um bug teu revelar.

--- a/.agent/workflows/audit.md
+++ b/.agent/workflows/audit.md
@@ -25,7 +25,7 @@ No **Claude Code**: fan-out de subagentes, um por lente. Noutros agentes: sequen
 > do frontmatter nao entrega necessariamente o que declara (ver `.claude/agents/code-reviewer.md`).
 
 1. **Organizacao & Conformidade com as Regras** — estrutura correta? Cumpre as suas proprias regras (`.agent/rules/`: ficheiros > 500 linhas, `any` proibido, data-fetching, tokens de design)? CLAUDE == GEMINI, wrappers <-> workflows.
-2. **Build & CI/CD** — `npm run build` passa? CI verde no branch (`gh pr checks`, nao a olho)? `.nvmrc` presente e o CI a le-lo via `node-version-file` em **todos** os jobs (nao versao hardcoded)? Guards locais espelham o pipeline? Tags/releases em dia?
+2. **Build & CI/CD** — `npm run build` passa? CI verde no branch (`gh pr checks`, nao a olho — e contar que existem checks: com zero, o comando sai 0)? `.nvmrc` presente e o CI a le-lo via `node-version-file` em **todos** os jobs (nao versao hardcoded)? Guards locais espelham o pipeline? Tags/releases em dia?
 3. **Arquitetura & Qualidade de Codigo** — complexidade, ficheiros grandes, dead code, duplicacao (DRY), anti-padroes (`anti-patterns.md`), acoplamento/fronteiras. **Dados/BD**: schema, migracoes, indices, integridade. **Resiliencia**: error boundaries, tratamento de erros, logging/observabilidade (como a app falha).
 4. **Seguranca** (exploitabilidade) — secrets versionados (gitleaks, se disponivel: `gitleaks detect`), authz/authn, validacao de input, headers, superficie de API. Cobre as categorias de `/security-tests`.
 5. **Performance** — bundle vs targets (`check-bundle-sizes.mjs`), waterfalls, N+1, imports pesados nao-lazy, Core Web Vitals*.

--- a/.agent/workflows/deploy.md
+++ b/.agent/workflows/deploy.md
@@ -31,9 +31,14 @@ Producao (main branch + {{BACKEND}} PROD)
 
 - Confirmar que o branch tem **todos os CI checks em verde** — com um comando, nao a olho.
   **Requer PR aberto** (sem PR, `gh pr checks` sai em erro "no pull requests found"):
-  ```bash
-  gh pr checks --watch    # espera ate terminarem; sai != 0 se algum falhar
-  ```
+```bash
+# GATE: exigir que os checks EXISTAM antes de exigir que estejam verdes.
+# `gh pr checks --watch` sai 0 quando nao ha check nenhum — na janela de propagacao
+# logo apos abrir o PR, um gate so com `--watch` passa sem nada ter sido verificado.
+n=$(gh pr checks --json state --jq 'length' 2>/dev/null || echo 0)
+[ "${n:-0}" -gt 0 ] || { echo "GATE: nenhum check reportado — o CI ainda nao arrancou"; exit 1; }
+gh pr checks --watch
+```
   Um agente em terminal nao consegue "ver no GitHub"; sem este comando o gate e so prosa.
 - Se algum check falhou, corrigir antes de continuar o deploy
 - **Security Audit**: por defeito e informativo (`continue-on-error`) — fica verde mesmo com advisories. **Abrir o log e ler o relatorio**; nao assumir que verde = limpo
@@ -120,8 +125,10 @@ Verificacao manual apenas (ver seccao 8).
 #    commits e ignora o pull_request_template.md (checklist obrigatoria).
 gh pr create --title "<tipo(scope): descricao>" \
              --body-file .github/pull_request_template.md
-# -> preencher a checklist no PR. SO DEPOIS de o PR existir e que ha checks para esperar:
-gh pr checks --watch         # GATE: espera ate terminarem; sai != 0 se algum falhar
+# -> preencher a checklist no PR. SO DEPOIS de o PR existir e que ha checks para esperar.
+#    Contar antes de esperar: com zero checks o `--watch` sai 0 e o gate passa vazio.
+n=$(gh pr checks --json state --jq 'length' 2>/dev/null || echo 0)
+[ "${n:-0}" -gt 0 ] && gh pr checks --watch || { echo "GATE: CI ainda nao arrancou"; exit 1; }
 gh pr merge --squash         # (ou merge pela UI do GitHub)
 # -> Deploy automatico para producao
 

--- a/.agent/workflows/review.md
+++ b/.agent/workflows/review.md
@@ -10,7 +10,9 @@ Checklist de revisao de codigo antes de fazer commit no {{PROJECT_NAME}}.
 - `npm run lint` — passa
 - CI pipeline verde no branch — **verificar com um comando, nao a olho**, mas so quando
   **ja existe PR** (o `/review` corre tipicamente antes do commit; sem PR o comando sai em
-  erro "no pull requests found"): `gh pr checks --watch` — espera e sai `!= 0` se falhar.
+  erro "no pull requests found"). **Contar os checks antes de os esperar** — com zero checks
+  o `gh pr checks --watch` sai `0` e o gate passa sem nada ter sido verificado:
+  `n=$(gh pr checks --json state --jq 'length'); [ "$n" -gt 0 ] && gh pr checks --watch`
   Antes de haver PR, os equivalentes locais sao o `tsc`/`lint`/testes desta checklist
 - Se CI falhou, corrigir antes de pedir review/merge
 - **Security Audit**: corre com `continue-on-error` por defeito, logo fica **sempre verde**.

--- a/.agent/workflows/security-tests.md
+++ b/.agent/workflows/security-tests.md
@@ -92,6 +92,21 @@ zap-cli quick-scan http://localhost:<PORT>
 
 **Quando usar:** Antes de releases com alteracoes significativas em auth, formularios ou APIs.
 
+### Alternativa: agente autonomo de pentesting
+
+Para projetos onde o scan de headers/inputs nao chega — auth complexa, multi-tenant,
+APIs publicas — existem agentes de pentesting autonomos (ex: `usestrix/strix`) que exploram
+a app em vez de correr uma checklist fixa.
+
+**Nao e dependencia deste template** e nao substitui as seccoes 1-4: e uma opcao a considerar
+no mesmo momento do ZAP, pre-release. Se o usares:
+
+- **So contra ambientes teus** (local ou staging dedicado) — nunca producao, e nunca contra
+  sistemas de terceiros sem autorizacao escrita.
+- Tratar os achados como o `/review` trata os do `code-reviewer`: **verificar cada um** contra
+  o codigo real antes de agir. Um agente que explora tambem alucina.
+- Os achados confirmados viram tickets no backlog, com severidade e esforco.
+
 ## 6. Regras para Novos Testes de Seguranca
 
 - Novos headers de seguranca -> adicionar teste em "Security Headers"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@
 - [ ] Doc guards pass (`node .agent/scripts/check-doc-versions.mjs`) — no WARN
 - [ ] If `.agent/scripts/` changed: guard tests pass (`node .agent/scripts/test-guards.mjs`, `node .agent/scripts/test-bundle-sizes.mjs`)
 - [ ] Backlog counters valid (`node .agent/scripts/check-backlog.mjs`) — 0 divergences
-- [ ] CI is green on the branch (`gh pr checks`) — never merge on red
+- [ ] CI is green on the branch — never merge on red, and **check that checks exist**: `gh pr checks --watch` exits 0 when none have been reported yet
 - [ ] `src/docs/CHANGELOG.md` updated
 - [ ] `.agent/context/backlog.md` updated (if applicable)
 - [ ] No secrets or credentials in committed files


### PR DESCRIPTION
## Summary

- Fixes the one defect the **real bootstrap dry-run** found: AP1, registered a commit earlier, was written about this repo's own test suite while `anti-patterns.md` is always-loaded context that every derived project inherits.
- Documents autonomous pentesting beside ZAP in `/security-tests` — as an option, not a dependency.

## Changes

**AP1 scoped to what a derived project inherits.** The dry-run cloned `main` into a throwaway directory outside the repo (so the template stays virgin), ran all three BOOTSTRAP phases, and added a `package.json` with the ten scripts BOOTSTRAP requires. A project about choir rehearsals was carrying 1.3 KB describing how `test-guards.mjs` asserts its warnings, with a detection grep that only works while that file exists.

The principle generalises to any project that tests a checker, so the entry stays. The template-specific detail does not: rewritten shorter, generic detection step, the repo's own mutation sweep as an example rather than the rule, and a line saying the entry is inherited and may be replaced. BOOTSTRAP §2.8 says the same where it tells the project what to do with the file.

**Autonomous pentesting documented as an option.** Prose only — no install, no script, nothing for the guards to check. Three caveats are stated because they matter: own environments only, verify every finding against real code before acting (an agent that explores also hallucinates), and confirmed findings become backlog tickets with severity and effort — the same treatment `/review` gives `code-reviewer` output.

## Checklist

- [x] `npx tsc --noEmit` / `npm run lint` / `npm run build` — N/A, no `package.json` in the bare template
- [x] Bundle sizes within targets — not configured; its own tests pass 16/16
- [x] Unit / E2E / security tests — N/A; the repo's tests are the two dependency-free suites
- [x] Dependency audit reviewed — N/A, no dependencies
- [x] Doc guards pass — 12 run / 7 skipped, exit 0
- [x] If `.agent/scripts/` changed — not changed here; both suites still 117/117 and 16/16
- [x] Backlog counters valid — exit 0
- [x] CI is green on the branch (`gh pr checks`)
- [x] `src/docs/CHANGELOG.md` updated — deliberately not: this repo ships it as an empty placeholder for the consumer project, unchanged since 352ad3c
- [x] `.agent/context/backlog.md` updated — N/A, untouched for the same reason
- [x] No secrets or credentials in committed files — `gitleaks` runs on this PR

## Test Plan

The dry-run is the test, and it is repeatable:

```bash
git clone --depth 1 <this repo> /tmp/probe && cd /tmp/probe
# substitute the placeholders per BOOTSTRAP Phase 1-2, generate the two rules,
# add a package.json with the ten scripts, then run Phase 3:
git grep -n --untracked "{{" -- ':!.agent/BOOTSTRAP.md' ':!README.md' \
  | sed -e 's/\${{[^}]*}}//g' -e 's/{{args}}//g' | grep "{{"   # must be empty
node .agent/scripts/check-doc-versions.mjs   # 15 guards, exit 0
node .agent/scripts/test-guards.mjs          # 117/117
node .agent/scripts/test-bundle-sizes.mjs    # 16/16
```

Measured on a bootstrapped project: **15 guards at exit 0, 117/117 and 16/16**. That last part is what the previous PR's fix bought — before it, five tests failed on any derived project's first commit.

**Reviewer focus.** Whether AP1 belongs in always-loaded context at all is the judgement call. It costs ~1.2 KB of every session in every derived project. Kept because the lesson it encodes is the most expensive thing this work produced — five review rounds of the same defect class — and because the scripts it refers to ship with the template. Reasonable to disagree and move it to `src/docs/`.
