### PR TITLE
fix(scripts): survive a Windows clone, and drop a count nothing checks

### DIFF
--- a/.agent/rules/anti-patterns.md
+++ b/.agent/rules/anti-patterns.md
@@ -57,8 +57,9 @@
   algum aviso disparou.
 - **Detecao em review**: pegar num input **valido e populado**, renomear/mover o que o
   verificador procura, e exigir que ele reprove. Se ele responder "vazio, nada a validar",
-  esta a mentir com exit `0`. Correr tambem cada verificador de uma subpasta: o resultado
-  tem de ser identico ao da raiz.
+  esta a mentir com exit `0`. Correr tambem cada verificador **de uma subpasta** (resultado
+  identico ao da raiz) e **num clone com CRLF** (`core.autocrlf=true` em Windows): um patch
+  ou regex com `"\n"` literal deixa de casar e o teste passa a nao afirmar nada.
 
 > Esta entrada vem do template. Aplica-se a qualquer projeto que escreva testes de
 > verificadores; se o teu projeto nao tiver nenhum, podes substitui-la pela primeira que

--- a/.agent/scripts/test-guards.mjs
+++ b/.agent/scripts/test-guards.mjs
@@ -174,7 +174,9 @@ test("G3: CHANGELOG em ordem ascendente avisa ordenacao", (dir) => {
 // Com o regex /g reutilizado, o 2o ficheiro era silenciosamente ignorado.
 test("G4: termo banido e apanhado em TODOS os ficheiros, nao so no primeiro", (dir) => {
   const g = readF(dir, GUARD).replace(
-    "const BANNED = [\n",
+    // Regex e nao literal: num clone com `core.autocrlf=true` o ficheiro tem `\r\n` e o
+    // literal "\n" nao casava — o patch nao se aplicava e a asserção rebentava (bem).
+    /const BANNED = \[\r?\n/,
     'const BANNED = [\n  { re: /Fronteiras/g, msg: "termo de teste" },\n'
   );
   // Um `.replace()` que nao casa devolve o ficheiro intacto, e o teste passaria pela razao
@@ -292,6 +294,23 @@ test("G10: wrapper vazio avisa", (dir) => {
   writeF(dir, ".gemini/commands/debug.toml", "");
 }, { code: 1, includes: [".gemini/commands/debug.toml nao aponta"] });
 
+
+// --- Clone em Windows: CRLF nao pode desligar nada ---------------------------
+// Um clone com `core.autocrlf=true` entrega `\r\n`. Dois patches de teste usavam o literal
+// "\n" e deixavam de casar, e as assercoes acrescentadas hoje rebentaram em voz alta em vez
+// de o teste passar pela razao errada. Isto fixa o comportamento.
+test("crlf: o guard passa num clone com line endings do Windows", (dir) => {
+  const paraCrlf = (p) => {
+    const b = readFileSync(file(dir, p));
+    if (!b.includes("\r\n")) writeFileSync(file(dir, p), b.toString("utf8").replace(/\n/g, "\r\n"));
+  };
+  for (const p of ["CLAUDE.md", "GEMINI.md", "AGENTS.md", ".nvmrc",
+                   ".agent/rules/core-rules.md", ".agent/rules/process-rules.md",
+                   ".agent/rules/anti-patterns.md", ".agent/rules/sync-docs.md",
+                   ".agent/rules/ticket-method.md", "src/docs/agent-guide.md"]) {
+    try { paraCrlf(p); } catch { /* nao existe nesta fixture */ }
+  }
+}, { code: 0, excludes: ["  WARN  "] });
 
 registarSettings();
 

--- a/.agent/scripts/tests-settings.mjs
+++ b/.agent/scripts/tests-settings.mjs
@@ -238,7 +238,9 @@ test("CHECKS: versao de dependencia desatualizada na doc avisa", (dir) => {
   // dependencias sairam do ficheiro principal. Patch no modulo, nao no GUARD.
   const alvo = `${GUARD_MODULES}/versions.mjs`;
   const g = readF(dir, alvo).replace(
-    "const CHECKS = [\n",
+    // Regex e nao literal: num clone com `core.autocrlf=true` o ficheiro tem `\r\n` e o
+    // literal "\n" nao casava — o patch nao se aplicava e a asserção rebentava (bem).
+    /const CHECKS = \[\r?\n/,
     'const CHECKS = [\n  { name: "Next.js", pkg: "next", pattern: /Next\\.js\\s+(\\d+(?:\\.\\d+(?:\\.\\d+)?)?)/g, files: [".agent/rules/core-rules.md"] },\n'
   );
   if (g === readF(dir, alvo)) throw new Error(`nao encontrei 'const CHECKS = [' em ${alvo}`);

--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ Branch protection rules (require status checks, block force push) require **GitH
 
 | Agent | File it auto-loads | Slash commands | Verified how |
 |-------|--------------------|----------------|--------------|
-| Claude Code | `CLAUDE.md` (+ `.claude/`) | native, 11 | Used throughout this template's own development |
-| Google Gemini CLI | `GEMINI.md` | native, 11 (`.gemini/commands/`) | Entry file and wrappers checked by Guards 2, 6, 7, 10 |
+| Claude Code | `CLAUDE.md` (+ `.claude/`) | native (all of them) | Used throughout this template's own development |
+| Google Gemini CLI | `GEMINI.md` | native (`.gemini/commands/`) | Entry file and wrappers checked by Guards 2, 6, 7, 10 |
 | GitHub Copilot | `.github/copilot-instructions.md` | no | File shipped and points to `AGENTS.md`; **not exercised in a real Copilot session** |
 | Cursor | `.cursor/rules/*.mdc` | no | Same — shipped, pointing to `AGENTS.md`; **not exercised in a real Cursor session** |
 | ChatGPT / Codex | `AGENTS.md` | no | Same — `AGENTS.md` is its documented convention; **not exercised** |


### PR DESCRIPTION
## Summary

- **A clone with `core.autocrlf=true` broke two tests.** `.replace("const BANNED = [\n", ...)` and the same for `CHECKS`: a literal `\n` does not match `\r\n`, so the patch never applied. Fixed with `/\[\r?\n/` plus a regression test that converts a fixture to CRLF.
- **A count written into prose an hour ago, with nothing checking it.** The compatibility table said "native, 11" for slash commands while BOOTSTRAP's Modo minimo says removing workflows is trivial. Fourth instance of this branch's own pattern — removed rather than guarded, since the workflow table already lists them.

## Changes

- `test-guards.mjs`, `tests-settings.mjs` — line-ending-agnostic patches; new `crlf:` test.
- `README.md` — the count is gone from the compatibility table.
- `anti-patterns.md` — AP2's detection recipe now says to run each checker from a subdirectory **and** on a CRLF clone.

## Test Plan

```
node .agent/scripts/test-guards.mjs           # 146
node .agent/scripts/test-backlog.mjs          #  25
node .agent/scripts/test-bundle-sizes.mjs     #  16
node .agent/scripts/test-mutation-sweep.mjs   #  14
node .agent/scripts/mutation-sweep.mjs        # 90/90, eight targets
```

To reproduce the CRLF finding: copy the repo, convert every `.md`/`.mjs`/`.json`/`.yml`/`.toml`
to CRLF, and run the six gates. Before this change `test-guards.mjs` exited 1; now all six
exit 0. The byte budget moves to NOTE, which is honest — CRLF costs a byte per line — and
stays below the 12000 WARN.

Worth noting why the CRLF failure was visible: those two `.replace()` calls got assertions
earlier on this branch, precisely because a non-matching replace returns the file untouched
and the test then passes for the wrong reason. On CRLF they threw instead of silently
asserting nothing.

## Checklist

> **Nota**: repo do template — sem `package.json` nem app, logo `tsc`/`lint`/`build`/`test`/`audit`
> nao se aplicam. Guards, doc sync e secrets corridos.

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] Bundle sizes within targets (if configured — `node .agent/scripts/check-bundle-sizes.mjs`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] E2E tests pass (`npm run test`)
- [ ] Security tests pass (`npm run test:security`)
- [ ] Dependency audit reviewed (`npm run test:audit`) — it is informative in CI, so green does not mean clean
- [ ] Doc guards pass (`node .agent/scripts/check-doc-versions.mjs`) — no WARN
- [ ] If `.agent/scripts/` changed: guard tests pass (`test-guards.mjs`, `test-bundle-sizes.mjs`, `test-backlog.mjs`, `test-mutation-sweep.mjs`)
- [ ] If a `check-*.mjs` changed: `node .agent/scripts/mutation-sweep.mjs` exits 0 (every warning site goes red; no checker without a suite)
- [ ] Backlog counters valid (`node .agent/scripts/check-backlog.mjs`) — 0 divergences
- [ ] CI is green on the branch — never merge on red, and **check that checks exist**: `gh pr checks --watch` exits 0 when none have been reported yet
- [ ] `src/docs/CHANGELOG.md` updated
- [ ] `.agent/context/backlog.md` updated (if applicable)
- [ ] No secrets or credentials in committed files
- [ ] **L ticket, or touches the core domain?** Independent reader ran (Fase 4 — the
      `code-reviewer` subagent, or a separate session given only the diff), each finding
      **verified against the real file**, and CONFIRMED vs PLAUSIBLE stated. It reads code;
      it is not a substitute for the `/review` passes above

