### PR TITLE
feat(workflows): /upgrade — pull template improvements into a derived project

### DIFF
--- a/.agent/BOOTSTRAP.md
+++ b/.agent/BOOTSTRAP.md
@@ -458,6 +458,8 @@ Apos completar todas as substituicoes e geracoes, apresentar ao utilizador:
 - [ ] `.editorconfig` reflete coding standards?
 - [ ] `LICENSE` tem copyright holder correto?
 - [ ] **Guards passam**: `check-doc-versions.mjs`, `check-backlog.mjs`, `test-guards.mjs`, `test-bundle-sizes.mjs`, `test-backlog.mjs` e `test-mutation-sweep.mjs` (todos exit 0 — apanham drift CLAUDE/GEMINI e workflows introduzido pela customizacao/traducao)
+- [ ] **`.agent/.template-version` gravado** com o commit do template de origem? Sem ele o
+  `/upgrade` deste projeto cai no modo por deteccao, que propoe mais e acerta menos
 - [ ] **Varredura de mutacao**: `node .agent/scripts/mutation-sweep.mjs` exit 0. Se adaptaste ou substituiste um `check-*.mjs`, ela diz se a suite correspondente ainda afirma algo — e reprova se o verificador novo vier sem suite nenhuma
 
 > **Nota (app):** este template e a camada de **agente + governance** — nao traz `package.json` nem codigo. Apos o bootstrap, integrar num projeto existente ou fazer scaffold da app, garantindo que o `package.json` expoe os scripts referenciados (`dev`, `build`, `lint`, `test:unit`, `test`, `test:security`, `test:audit`, `test:all`, `test:ui`, `test:headed`). **`test:all` = unit + E2E + security + audit** — fixar esta definicao, que os workflows citam. Ate la, o CI salta os jobs (via `detect`) e os workflows apontam para scripts que ainda nao existem.
@@ -474,6 +476,21 @@ Ficheiros de governance customizados:    ~4 (CODEOWNERS, PR template, issue temp
 ### Proximo passo
 
 Sugerir ao utilizador:
+
+**Gravar de que ponto do template este projeto nasceu** — sem isto, o `/upgrade` nao sabe o
+que ja tens e tem de adivinhar por deteccao de capacidades em vez de por diff:
+
+```bash
+# Correr AINDA dentro do clone do template, antes de apagar a origem, ou apontando-lhe:
+printf 'template: %s\ncommit: %s\ndata: %s\n' \
+  "$(git remote get-url origin 2>/dev/null || echo desconhecido)" \
+  "$(git rev-parse HEAD)" \
+  "$(date +%F)" > .agent/.template-version
+```
+
+> Este ficheiro **nao existe no template** — nasce aqui, com o commit de origem deste
+> projeto. O `/upgrade` le-o para saber o que mudou desde entao (Modo A). Sem ele cai no
+> Modo B, que funciona mas propoe mais e com menos precisao.
 
 ```bash
 # Verificar que nao ficou nenhum placeholder (mesmo sweep da Fase 3 — zero linhas)

--- a/.agent/rules/sync-docs.md
+++ b/.agent/rules/sync-docs.md
@@ -68,6 +68,12 @@ Nao basta atualizar apenas os ficheiros de contexto (`.agent/context/`) — e ob
 | **Script** (`.agent/scripts/X.mjs`) | passo em `.github/workflows/ci.yml` — **obrigatorio** e sem gate do `detect` se for um `test-*.mjs` (job `guard-tests`), opt-in comentado se depender de build ou de configuracao do projeto (`TARGETS`, `CHECKS`); `core-rules.md` (seccao scripts); `README.md` (arvore + tabela); **e os sitios que o INVOCAM**: `review.md`, `deploy.md`, `.github/pull_request_template.md`, `BOOTSTRAP.md` §2.4 — sem isto o guard fica documentado em todo o lado e corrido por nada. Se e um guard, criar tambem o `test-X.mjs` com os controlos negativos |
 | **Context** (`.agent/context/X.md`) | decidir **importado** (`@` em CLAUDE.md + GEMINI.md) vs **arquivo** (nao importado, historico inerte); **`AGENTS.md`**; `README.md`; `agent-guide.md`; **ponto novo na checklist de 1-24 acima**; classificacao substituido/acumulado/permanente em `process-rules.md`; nota dos `*-archive.md` em `CLAUDE.md`/`GEMINI.md` |
 
+> **Sentido inverso**: quando o **template de origem** ganha algo e se quer trazer para um
+> projeto derivado, o workflow e `/upgrade` (`.agent/workflows/upgrade.md`). Decide por
+> **categoria de ficheiro** — nunca por lista de nomes, que envelhece — e o `.agent/context/*`
+> nunca se toca. Se acrescentares uma categoria a matriz acima, acrescenta a linha
+> correspondente a tabela do `/upgrade`.
+
 > Regra de paridade: qualquer edicao a `CLAUDE.md` tem espelho em `GEMINI.md` (so difere `@[...]`) — validado por `check-doc-versions.mjs`.
 
 ## Contra-verificacao por grep (anti-drift)

--- a/.agent/rules/ticket-method.md
+++ b/.agent/rules/ticket-method.md
@@ -13,6 +13,21 @@ Seis fases: **explicar antes de fazer** (0) · desenvolver (1) · um loop com cr
 O criterio diz o que conta como achado; **nao** diz quando o ciclo acaba. Isso e sempre uma
 decisao do utilizador (Fases 2 e 3).
 
+E ha, depois do commit, algo que **nao e do agente e nao se numera: usar** o que mudou. (Nao
+lhe chamo fase nem passagem de proposito — as fases sao seis, 0 a 5, e "passagem" ja significa
+uma volta da Fase 3.) Nao e
+um remate opcional — sao **tres instrumentos que apanham classes diferentes**, e o terceiro e
+o unico que apanha uma decisao errada:
+
+| Instrumento | Apanha |
+|-------------|--------|
+| As Fases 2-3 (o teu julgamento) | o que **acabaste de escrever** |
+| A Fase 4 (leitor independente) | o que **nao consegues ver por teres escrito** |
+| **Usar** (nao e do agente) | o que **decidiste mal** — inclui o que nunca chegou a existir |
+
+Detalhe mais abaixo, em _"A fase que nao e do agente"_. Saltar as tres nao e ir mais rapido:
+e trocar tres tipos de deteccao por um.
+
 O que escala com o tamanho do ticket sao tres delas — a **Fase 0** (do chat ao ficheiro com
 alternativas), a **Fase 3** (quantas passagens esperar) e a **Fase 4** (se corre). As outras
 tres sao **binarias**: um controlo negativo, o `tsc 0` e o relatorio de 5 pontos valem igual
@@ -197,11 +212,20 @@ E o Git pergunta-se **um passo por vez**: commit, depois push, depois PR, depois
 Depois de cada ticket, **uma passagem a usar o que mudou**. Num produto com UI, e abrir o
 ecra; numa lib, e consumi-la de fora; num template, e criar um projeto a partir dele.
 
-Isto nao e opcional nem cosmetico. Numa sessao medida, cinco rondas de review adversarial
-encontraram 22 defeitos — todos em codigo escrito minutos antes. **Uma unica passagem de uso
-encontrou um defeito de desenho que nenhuma das cinco viu**, e usar um gate a serio revelou
-que ele passava com zero verificacoes. Sao classes diferentes: a revisao apanha o que
-acabaste de escrever, o uso apanha o que decidiste mal.
+Isto nao e opcional nem cosmetico, e a medicao e especifica. Numa sessao real:
+
+- **A revisao** (Fases 2-3, seis passagens) encontrou 22 defeitos — todos em codigo escrito
+  minutos antes.
+- **O leitor independente** (Fase 4) encontrou, em dezasseis minutos, tres defeitos ALTO que
+  as seis passagens nao viram — incluindo um check de seguranca que podia ser desligado com a
+  suite toda verde. A revisao falhou ai porque quem escreveu o teste **sabe o que ele queria
+  dizer**.
+- **Usar** encontrou o que nao existia: simular o bootstrap revelou que faltava um verificador
+  inteiro (nenhuma revisao podia encontrar codigo ausente); converter o repo para CRLF revelou
+  dois testes que nao afirmavam nada; e correr um gate de CI a serio revelou que ele passava
+  com zero verificacoes.
+
+Nenhum destes tres substitui os outros. O erro nao e escolher mal — e escolher so um.
 
 ## O que o metodo nao faz
 

--- a/.agent/workflows/upgrade.md
+++ b/.agent/workflows/upgrade.md
@@ -1,0 +1,112 @@
+# /upgrade — Trazer melhorias do template para este projeto
+
+Workflow para atualizar um projeto **derivado** com melhorias feitas no template de origem,
+sem apagar o que e deste projeto.
+
+> **E o inverso da Matriz de Propagacao** (`.agent/rules/sync-docs.md`). A matriz responde a
+> _"acrescentei X, onde tem de ir"_; este workflow responde a _"o template ganhou X, o que
+> trago"_. Por isso decide por **categoria de ficheiro**, e nao por uma lista de nomes: uma
+> lista envelhece a cada alteracao do template, uma categoria nao.
+
+## 0. Fase 0 — mostrar e esperar
+
+**Nada e copiado antes de aprovacao.** Este workflow toca em ficheiros que carregam o estado
+e as decisoes do projeto; um `cp -R` mal apontado apaga trabalho que nao esta em mais sitio
+nenhum. Apresentar sempre: o que se traz, o que se ignora, e o diff de tudo o que ja existe.
+
+## 1. Descobrir de que ponto o projeto partiu
+
+```bash
+cat .agent/.template-version 2>/dev/null || echo "SEM MARCA"
+```
+
+Isto decide o modo. Os dois sao validos; o segundo e o normal em projetos criados antes de a
+marca existir.
+
+### Modo A — com marca (`.agent/.template-version` existe)
+
+O ficheiro traz o commit do template de onde este projeto nasceu (ou da ultima atualizacao).
+
+```bash
+TPL=<caminho-ou-url-do-template>
+SHA=$(grep -oE '\b[0-9a-f]{7,40}\b' .agent/.template-version | head -1)
+git -C "$TPL" log --oneline "$SHA"..main          # o que mudou desde entao
+git -C "$TPL" diff --stat "$SHA"..main            # e em que ficheiros
+```
+
+Trabalhar **so** sobre esses ficheiros. E o modo preciso: nao propoe nada que o projeto ja
+tenha.
+
+### Modo B — sem marca (nao se sabe o ponto de partida)
+
+**Nao fazer diff contra o template.** Sem baseline, o diff marca tudo como novo — incluindo o
+que o projeto ja tem e possivelmente customizou — e a proposta fica inutil ou destrutiva.
+
+Em vez disso, **detetar capacidades**: por cada coisa que o template tem, verificar se este
+projeto a tem, e so entao propor. Perguntas em vez de diffs:
+
+```bash
+TPL=<caminho-ou-url-do-template>
+# 1. Que ficheiros o template tem que este projeto nao tem?
+(cd "$TPL" && git ls-files) | while read -r f; do [ -e "$f" ] || echo "AUSENTE: $f"; done
+# 2. Que scripts de verificacao existem em cada lado?
+ls .agent/scripts/ ; ls "$TPL/.agent/scripts/"
+# 3. Que workflows existem em cada lado?
+ls .agent/workflows/ ; ls "$TPL/.agent/workflows/"
+```
+
+O que esta **ausente** e candidato a copia. O que existe nos dois vai para a tabela da secao
+2 e decide-se por categoria — nunca por overwrite cego.
+
+## 2. Decidir por categoria, nao por ficheiro
+
+| Categoria | O que fazer | Porque |
+|-----------|-------------|--------|
+| `.agent/context/*`, `src/docs/CHANGELOG.md` | **NUNCA tocar** | E o estado e a historia deste projeto. Nao existem em mais sitio nenhum |
+| `.agent/scripts/*.mjs` | Copia limpa, **preservando** as constantes de configuracao deste projeto (`TARGETS` no bundle checker, `CHECKS` e `BANNED` nos doc guards) e substituindo os placeholders | Os verificadores sao genericos; so a configuracao e do projeto |
+| `.agent/rules/` com conteudo de dominio (`business-logic`, `pages-architecture`) | **Nunca copiar.** Sao 100% deste projeto | Foram gerados no bootstrap a partir das respostas |
+| `.agent/rules/` acumuladas (`anti-patterns`) | **Acrescentar** entradas novas; nunca substituir o ficheiro | O projeto tem anti-padroes proprios, derivados dos seus bugs |
+| `.agent/rules/` de processo (`core-rules`, `process-rules`, `sync-docs`, `ticket-method`) | **Diff obrigatorio.** Se o projeto nao as customizou, copia; se customizou, integrar a mao | Misturam regra generica com decisoes do projeto |
+| `.agent/workflows/*` + os dois wrappers | Copia se nao customizados; diff se sim. Ao **acrescentar** um workflow, propagar como manda a matriz (wrappers + tabelas) | Os wrappers sao ponteiros finos; a logica esta no workflow |
+| Pontos de entrada (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/*.mdc`) | Diff. Preservar a stack e a descricao do projeto; trazer estrutura e tabelas | Cabecalho e do projeto, corpo e do template |
+| `.github/workflows/*` | **So os jobs em falta** (ex: `guard-tests`). Nao substituir o CI do projeto | O CI do projeto pode ter passos proprios |
+| `.claude/settings.json` | Trazer regras de `deny`/`ask` novas; **acrescentar** ao `allow` os scripts novos | O `allow` do projeto reflete o que ele corre |
+
+## 3. Verificar — e e aqui que o upgrade se prova
+
+Depois de aplicar, correr **nesta ordem**:
+
+```bash
+node .agent/scripts/check-doc-versions.mjs     # paridade, orcamentos, placeholders
+node .agent/scripts/check-backlog.mjs          # contadores do backlog
+node .agent/scripts/test-guards.mjs            # e as outras suites test-*
+node .agent/scripts/mutation-sweep.mjs         # custa minutos; e o que interessa
+```
+
+Ler com atencao dois resultados da varredura:
+
+- **`SEM SUITE`** para um verificador deste projeto -> esse guard nao tem testes. Nao
+  silenciar: escrever a suite. Um verificador nao verificado da a aparencia de confianca.
+- **`ALVO AUSENTE`** -> um verificador foi renomeado ou removido sem atualizar o `PARES`.
+
+Correr tambem **de uma subpasta** (`cd src && node ../.agent/scripts/...`): o resultado tem de
+ser identico. E, se alguem no projeto trabalha em Windows, confirmar num clone com CRLF.
+
+## 4. Gravar o novo ponto de partida
+
+```bash
+TPL=<caminho-ou-url-do-template>
+printf 'template: %s\ncommit: %s\ndata: %s\n' \
+  "$(git -C "$TPL" remote get-url origin 2>/dev/null || echo "$TPL")" \
+  "$(git -C "$TPL" rev-parse main)" \
+  "$(date +%F)" > .agent/.template-version
+```
+
+Sem isto, o proximo `/upgrade` cai outra vez no Modo B. **E o unico passo que torna o
+proximo upgrade barato**, e e o que faltava a este.
+
+## 5. Relatorio (Fase 5) e so depois o commit
+
+O relatorio diz o que foi trazido **por categoria**, o que foi deliberadamente ignorado e
+porque, os conflitos que exigiram integracao a mao, e o resultado dos verificadores da secao
+3 — incluindo qualquer `SEM SUITE` que tenha aparecido, que e um ticket e nao um detalhe.

--- a/.claude/commands/upgrade.md
+++ b/.claude/commands/upgrade.md
@@ -1,0 +1,5 @@
+---
+description: Trazer melhorias do template de origem para este projeto, sem apagar o que e do projeto
+---
+
+Ler e seguir `.agent/workflows/upgrade.md`.

--- a/.gemini/commands/upgrade.toml
+++ b/.gemini/commands/upgrade.toml
@@ -1,0 +1,2 @@
+description = "Trazer melhorias do template de origem para este projeto, sem apagar o que e do projeto"
+prompt = "Le e segue .agent/workflows/upgrade.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Stack: {{STACK}}.
 
 ## Workflows (ler on-demand quando invocados)
 
-`setup` · `plan` · `review` · `design-review` · `refactor` · `deploy` · `debug` · `e2e-tests` · `security-tests` · `audit` · `market-scan`
+`setup` · `plan` · `review` · `design-review` · `refactor` · `deploy` · `debug` · `e2e-tests` · `security-tests` · `audit` · `market-scan` · `upgrade`
 → ficheiros em `.agent/workflows/<nome>.md`. No Claude Code sao tambem slash commands (`.claude/commands/`).
 
 ## Fronteiras (prioridade maxima)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Stack: {{STACK}}.
 | Deploy para producao      | `.agent/workflows/deploy.md`           |
 | Auditoria completa        | `.agent/workflows/audit.md`            |
 | Analise de mercado        | `.agent/workflows/market-scan.md`      |
+| Atualizar do template     | `.agent/workflows/upgrade.md`          |
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -59,6 +59,7 @@ Stack: {{STACK}}.
 | Deploy para producao      | `.agent/workflows/deploy.md`           |
 | Auditoria completa        | `.agent/workflows/audit.md`            |
 | Analise de mercado        | `.agent/workflows/market-scan.md`      |
+| Atualizar do template     | `.agent/workflows/upgrade.md`          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ When you open a new AI session in any project using this template, the agent **a
 │   ├── e2e-tests.md            <- /e2e-tests — E2E tests (Playwright)
 │   ├── security-tests.md       <- /security-tests — Security tests
 │   ├── audit.md                <- /audit — Full project/app health audit (multi-lens)
-│   └── market-scan.md          <- /market-scan — Market/competitor analysis + feature ideation
+│   ├── market-scan.md          <- /market-scan — Market/competitor analysis + feature ideation
+│   └── upgrade.md              <- /upgrade — Pull template improvements into a derived project
 └── scripts/
     ├── check-bundle-sizes.mjs  <- Bundle size checker (Next.js)
     ├── check-doc-versions.mjs  <- Doc guards: entry point + doc-parity guards

--- a/src/docs/agent-guide.md
+++ b/src/docs/agent-guide.md
@@ -93,6 +93,7 @@ Os workflows sao sequencias de passos que o Agente executa para tarefas especifi
 | **`/deploy`**         | Deploy Producao    | Passos finais para enviar para producao.                |
 | **`/audit`**          | Auditoria Completa | Estado holistico do projeto/app (milestone; multi-lente).|
 | **`/market-scan`**    | Analise de Mercado | Concorrencia + gaps + ideacao de features (web).        |
+| **`/upgrade`**        | Atualizar do template | Trazer melhorias do template de origem sem perder o que e do projeto. |
 
 > **Como sao invocados:** os workflows vivem em `.agent/workflows/` e sao lidos **on-demand** (nao carregam sempre no contexto). No **Claude Code** existem tambem como slash commands nativos em `.claude/commands/` (wrappers finos). Com **outro agente** (Gemini, Cursor, Copilot), dizes _"corre o /plan"_ ou _"segue `.agent/workflows/plan.md`"_ — le o mesmo ficheiro. O `.claude/` (commands, `agents/` subagentes read-only, `settings.json` de permissions) e so-Claude; os outros ignoram-no. **O que se perde fora do Claude Code esta listado no `README.md`** (fronteira de permissoes, subagente da Fase 4, slash commands) — a logica nao, essa vive toda em `.agent/`. Entry cross-tool: `AGENTS.md`, com ponteiros finos em `.github/copilot-instructions.md` e `.cursor/rules/*.mdc` porque sao esses os ficheiros que o Copilot e o Cursor carregam.
 


### PR DESCRIPTION
## Summary

- **`/upgrade` (new)** — the template had no answer to *"the template improved, what do I pull into my project"*. Every improvement created N manual update tasks, each re-derived by hand.
- It is the **inverse of the propagation matrix**: that answers "I added X, where must it go"; this answers "the template gained X, what do I take". Same classification backwards — so it decides by **file category**, never by a name list, which would go stale on every template change.
- The bootstrap now writes `.agent/.template-version`, so the next upgrade knows where the project started.

## Changes

- `.agent/workflows/upgrade.md` (new) + both wrappers + the four entry tables. Adding it made the guards flag all five propagation targets — the matrix working on its own author.
- `.agent/BOOTSTRAP.md` — writes the version marker and checks for it in the final checklist.
- `.agent/rules/sync-docs.md` — records the inverse rule, so the matrix and `/upgrade` cannot diverge.
- `.agent/rules/ticket-method.md` — the use phase moves from a closing remark into the framing.

## Test Plan

Ran the workflow's own commands literally against a derived project built earlier from this
template:

```
Mode B (no marker — the real case for existing projects)
  → listed the absent files correctly
Step 4 (write the marker)
  → produced template/commit/date, and `.gitignore` does not hide it
Mode A (with the marker)
  → empty against HEAD, and 10 commits / 33 files against an earlier baseline
```

Plus the six gates: `check-doc-versions` and `check-backlog` at 0, four suites at 201 tests,
mutation sweep 90/90 across eight targets, 12 workflows in parity.

**Design note for the reviewer**: a version-diff upgrade was the obvious design and does not
work. With no recorded baseline, a diff against today's template marks everything as new —
including what the project already has and may have customised. Mode B therefore says
explicitly *do not diff*, and detects capabilities instead.

## Checklist

> **Nota**: repo do template — sem `package.json` nem app, logo `tsc`/`lint`/`build`/`test`/`audit`
> nao se aplicam. Guards, doc sync e secrets corridos.

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] Bundle sizes within targets (if configured — `node .agent/scripts/check-bundle-sizes.mjs`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] E2E tests pass (`npm run test`)
- [ ] Security tests pass (`npm run test:security`)
- [ ] Dependency audit reviewed (`npm run test:audit`) — it is informative in CI, so green does not mean clean
- [ ] Doc guards pass (`node .agent/scripts/check-doc-versions.mjs`) — no WARN
- [ ] If `.agent/scripts/` changed: guard tests pass (`test-guards.mjs`, `test-bundle-sizes.mjs`, `test-backlog.mjs`, `test-mutation-sweep.mjs`)
- [ ] If a `check-*.mjs` changed: `node .agent/scripts/mutation-sweep.mjs` exits 0 (every warning site goes red; no checker without a suite)
- [ ] Backlog counters valid (`node .agent/scripts/check-backlog.mjs`) — 0 divergences
- [ ] CI is green on the branch — never merge on red, and **check that checks exist**: `gh pr checks --watch` exits 0 when none have been reported yet
- [ ] `src/docs/CHANGELOG.md` updated
- [ ] `.agent/context/backlog.md` updated (if applicable)
- [ ] No secrets or credentials in committed files
- [ ] **L ticket, or touches the core domain?** Independent reader ran (Fase 4 — the
      `code-reviewer` subagent, or a separate session given only the diff), each finding
      **verified against the real file**, and CONFIRMED vs PLAUSIBLE stated. It reads code;
      it is not a substitute for the `/review` passes above

