### PR TITLE
docs(method): bring back the evidence a derived project accumulated

### DIFF
--- a/.agent/rules/core-rules.md
+++ b/.agent/rules/core-rules.md
@@ -73,6 +73,10 @@
 - Componentes duplicados devem ser unificados com generics.
 - One-time form init com guard `initialized` para evitar resets de revalidation.
 
+### Diff minimo
+
+- **Nao reformatar o que o ticket nao toca.** Um formatador que o projeto nao usa (`npx prettier` num repo sem prettier) inflou um diff de 1 linha para `+225/-99` — a revisao passa a procurar a alteracao real no meio de ruido. Formatacao errada e ticket proprio.
+
 ### Reutilizacao & DRY
 
 - **Procurar antes de criar**: `grep`/pesquisa pelo que ja existe (util, hook, componente) antes de escrever codigo novo.
@@ -128,7 +132,6 @@
 - **`.github/CODEOWNERS`**: Define reviewers automaticos por ficheiro/pasta.
 - **`LICENSE`**: MIT (ou outra licenca adequada ao projeto).
 - **Branch Protection**: Branch protection rules (require status checks, bloquear force push) requerem GitHub Pro em repos privados. O CI funciona como **semaforo informativo**. Se disponivel, ativar em GitHub Settings > Branches > Branch protection rules.
-- **Tags & Releases**: Cada versao (vX.Y.Z) tem uma tag anotada no Git. Tags sao criadas apos merge de sprints/releases para main. Visiveis em GitHub > Code > Tags.
 
 ### Docs & Knowledge Sync
 

--- a/.agent/rules/ticket-method.md
+++ b/.agent/rules/ticket-method.md
@@ -39,6 +39,26 @@ nao vale numa mudanca de texto.
 
 ---
 
+## De onde vem cada regra
+
+Nenhuma foi inventada em abstracto. Cada uma veio de um erro **que aconteceu** — metade neste
+repo (marcadas `T`, de template) e metade num projeto construido a partir dele (`P`), que e a
+razao de estarem aqui: sao as que qualquer projeto repete.
+
+| Erro real | Regra que ficou | |
+|-----------|-----------------|-|
+| Um `tail -1` mostrou `125 passed` e engoliu o `1 failed` | **Nunca filtrar** o sumario de uma corrida (Fase 2) | `P` |
+| Uma assercao passava com o defeito no ecra — um `toHaveCount(0)` cumpre-se no primeiro instante em que a contagem e zero | Cada teste novo nasce com o seu **controlo negativo** (Fase 1) | `P` |
+| Duas passagens de `/review` seguidas nao encontraram nada, por serem a mesma checklist | Cada passagem **declara o angulo** antes de correr (Fase 3) | `P` |
+| Uma varredura reportou `39/39` medindo **3 sitios de 21**: o padrao so via `warn(`, e o verificador emitia por um wrapper `flag()` | Cobertura de mutacao **derivada por script**, nunca contada a mao (Fase 1) | `T` |
+| Um check de seguranca — o que obriga a pedir autorizacao antes de `git commit`/`push` — podia ser desligado com a suite **toda verde** | O **leitor independente** da Fase 4 e obrigatorio num `L` ou no nucleo do dominio | `T` |
+| Faltava um verificador **inteiro**: um placeholder esquecido no bootstrap nao avisava ninguem | **Usar** o que se construiu — nenhuma revisao encontra codigo que nao existe | `T` |
+| Seis passagens minhas declararam o trabalho limpo; uma leitura independente achou tres defeitos ALTO em 16 minutos | "Validei e esta limpo" **nao e informacao** quando o validador e o autor | `T` |
+| Um `npx prettier` num projeto sem prettier inflou um diff para `+225/-99` | **Nao reformatar o que o ticket nao toca** (Fase 1) | `P` |
+
+> Num projeto derivado, **substitui estas linhas pelas tuas**. A tabela vale pelos erros que
+> *tu* cometeste: sao esses que a tua equipa reconhece e por isso respeita.
+
 ## Fase 0 — Explicar, e esperar
 
 Antes de tocar no codigo: o problema, os ficheiros que vao mudar, a abordagem, **as
@@ -226,6 +246,19 @@ Isto nao e opcional nem cosmetico, e a medicao e especifica. Numa sessao real:
   com zero verificacoes.
 
 Nenhum destes tres substitui os outros. O erro nao e escolher mal — e escolher so um.
+
+## O que custa
+
+Aplicado por inteiro a tudo, multiplica o tempo por ticket por **2 a 3**. E por isso que tres
+fases escalam por tamanho: sem escala, o metodo e abandonado a segunda semana.
+
+A **Fase 4** e a unica com um custo grande e mensuravel. Medido neste repo: uma passagem sobre
+dois commits (33 ficheiros) consumiu **~168k tokens** e 16 minutos, e devolveu tres defeitos
+ALTO que seis passagens minhas nao viram — um deles a fronteira de seguranca. E cara e vale a
+pena onde a tabela da Fase 4 diz que corre; nao vale num `S`.
+
+O resto e quase gratis em tempo de maquina: os controlos negativos correm com a suite, e a
+varredura de mutacao custa minutos **uma vez** por alteracao a um verificador, nao por commit.
 
 ## O que o metodo nao faz
 

--- a/.agent/workflows/design-review.md
+++ b/.agent/workflows/design-review.md
@@ -5,7 +5,41 @@ Rubrica de qualidade visual e de experiencia do {{PROJECT_NAME}}. Correr **antes
 **Tier do projeto (bootstrap): {{QUALITY_TIER}}** — MVP < Polido < Elite. Quanto mais alto o tier, mais criterios sao obrigatorios (marcados `[Polido]` / `[Elite]`).
 
 > **Sem notas numericas.** Cada criterio e **passa / falha / N/A**, com um problema concreto e uma correcao. So aplicavel a alteracoes com **UI** — para APIs/CLI/libs, saltar. Ler tambem `.agent/rules/pages-architecture.md` (design system do projeto) e a seccao `### Qualidade & Design (Barra: {{QUALITY_TIER}})` em `core-rules.md`.
-> **Verificacao:** a11y (AA) e performance (Core Web Vitals) — sobretudo no tier Elite — **nao tem harness automatico** neste template; verificar com **ferramentas/manualmente** (ex: axe DevTools, Lighthouse, leitor de ecra, navegacao por teclado). Um projeto pode adicionar um check opt-in (axe/Lighthouse CI) — nao assumido por defeito.
+> **Verificacao:** este template **nao traz** o harness de medicao — depende do runner de E2E
+> e dos seletores do projeto. Mas a parte desta rubrica que e **numero** nao devia ser lida a
+> olho, e a seccao seguinte diz exatamente o que medir e a armadilha de cada medicao.
+
+---
+
+## 0. A parte que e numero: medir, nao opinar
+
+Desta rubrica, **quatro** criterios sao numero e devem ser medidos: contraste, alvos de toque,
+overflow horizontal e CLS. Todo o resto — hierarquia, microcopy, fluxos, ordem de tabulacao,
+armadilhas de foco, leitores de ecra — le-se a olho, e nao ha harness que o substitua. Nao
+confundir os dois grupos: medir o que e opiniao da falsa precisao, e opinar sobre o que e
+numero da falsa aprovacao.
+
+Construir isto uma vez, no runner de E2E do projeto, e correr **a pedido** — nao em cada
+push: mede a app inteira e o seu lugar e antes de dar UI por concluida.
+
+| Medir | A armadilha que da um resultado FALSO |
+|-------|----------------------------------------|
+| **Contraste** (AA: 4.5:1; 3:1 se >= 24px, ou >= 18.66px negrito) | Com tokens modernos, `getComputedStyle` devolve **`oklch(...)`**. Ler esses tres numeros como se fossem RGB da valores sem relacao com a realidade — deu **cinco falsos positivos** num projeto real. Deixar a conversao ao **proprio browser** (via `canvas`) em vez de escrever um conversor de espacos de cor, que seria mais codigo por testar do que o que se esta a testar. Fundo transparente compoe-se **camada a camada** |
+| **Alvos de toque** (>= 44px) | Medir o `<input>` de 16px em vez do `<label>` que o envolve. O alvo real e a caixa onde se acerta com o dedo; medir a dimensao errada da um "passou" que nao quer dizer nada |
+| **Overflow horizontal** | `document.scrollWidth` **nao serve** se o `body` tiver `overflow-x-hidden`: o que transborda fica escondido e a pagina jura que nao transborda. Medir **elemento a elemento** |
+| **CLS** (<= 0.1) | Medir com o CSS a meio produz uma leitura otimista. Observar com `buffered: true` **depois** de as fontes estarem prontas e os esqueletos sairem — e reportar **qual o no** que saltou, senao nao se sabe o que corrigir |
+
+> **Porque isto esta escrito e nao apenas feito**: num projeto real a medicao foi escrita a
+> mao tres vezes no mesmo dia, e **duas dessas versoes deram resultados falsos** — uma leu o
+> `oklch` como RGB (linha 1), a outra mediu antes de o CSS assentar e concluiu que estava tudo
+> bem quando nao estava (linha 4). Uma medicao que se reinventa a cada review nao e uma
+> medicao: e uma opiniao com numeros.
+
+**Limiares que se medem em vez de se escolherem**: se uma transicao deliberada da app exceder
+o limiar, nao se relaxa o limiar a olho — mede-se o valor real dessa transicao, fixa-se o
+tecto **ligeiramente acima** (para o teste nao falhar com arredondamento de um tipo de letra),
+e o custo dela vira **ticket**. Assim qualquer salto **novo** maior continua a falhar.
+
 
 ## 1. Design & Consistencia
 - [ ] Usa os **design tokens** do projeto (cor, espacamento, tipografia) — zero valores hardcoded soltos
@@ -21,14 +55,14 @@ Rubrica de qualidade visual e de experiencia do {{PROJECT_NAME}}. Correr **antes
 - [ ] Confirmacao para accoes destrutivas; desfazer quando possivel
 
 ## 3. Estados (o que separa amador de premium)
-- [ ] **Loading**: skeletons/placeholders (nao spinners nus), sem layout shift
+- [ ] **Loading**: skeletons/placeholders (nao spinners nus), sem layout shift — **medir** (§0), nao inspecionar: "tem esqueleto" nao e uma medicao
 - [ ] **Empty**: estado vazio com orientacao/CTA (nao ecra em branco)
 - [ ] **Error**: mensagem util e accionavel (o que aconteceu + como resolver)
 - [ ] **Success**: feedback claro de accao concluida
 - [ ] Estados **hover / focus / active / disabled** em todos os interativos
 
 ## 4. Acessibilidade (a11y) — [Polido: AA basico · Elite: AA completo]
-- [ ] Contraste >= WCAG AA (4.5:1 texto normal, 3:1 grande)
+- [ ] Contraste >= WCAG AA (4.5:1 texto normal, 3:1 grande) — **medir** (§0: `oklch` nao se le como RGB)
 - [ ] **Foco visivel** em todos os interativos; ordem de tab logica
 - [ ] Navegavel 100% por teclado; sem armadilhas de foco
 - [ ] Semantica correta (headings, landmarks, `label` em inputs); ARIA so quando necessario
@@ -39,7 +73,7 @@ Rubrica de qualidade visual e de experiencia do {{PROJECT_NAME}}. Correr **antes
 - [ ] Border-radius, sombras e bordas consistentes e subtis
 - [ ] Densidade e whitespace equilibrados (nao apertado, nao vazio)
 - [ ] Iconografia coerente (mesmo set e peso)
-- [ ] Imagens otimizadas e com dimensoes definidas (sem CLS)
+- [ ] Imagens otimizadas e com dimensoes definidas (sem CLS — §0)
 
 ## 6. Microcopy & Conteudo
 - [ ] Labels e botoes claros, orientados a accao (verbos)
@@ -52,8 +86,8 @@ Rubrica de qualidade visual e de experiencia do {{PROJECT_NAME}}. Correr **antes
 - [ ] Nada que bloqueie ou distraia; respeita `prefers-reduced-motion`
 
 ## 8. Responsividade
-- [ ] Mobile-first; viewport de telemovel sem overflow horizontal
-- [ ] Alvos de toque >= 44px; conteudo re-flui (nao so encolhe)
+- [ ] Mobile-first; viewport de telemovel sem overflow horizontal (**medir elemento a elemento** — §0)
+- [ ] Alvos de toque >= 44px (**medir a caixa clicavel**, nao o input — §0); conteudo re-flui (nao so encolhe)
 - [ ] Sem grids fixos que quebram (`flex flex-col sm:flex-row`)
 
 ## 9. SEO & Metadata [so apps web com paginas publicas]
@@ -65,7 +99,7 @@ Rubrica de qualidade visual e de experiencia do {{PROJECT_NAME}}. Correr **antes
 ## 10. Performance percebida [ligado ao perf budget]
 - [ ] Sem waterfalls; skeletons enquanto carrega
 - [ ] Bundle dentro do target (`check-bundle-sizes.mjs`); imports pesados lazy
-- [ ] Core Web Vitals saudaveis (LCP, CLS, INP) — obrigatorio no tier Elite
+- [ ] Core Web Vitals saudaveis (LCP, CLS, INP) — obrigatorio no tier Elite; o CLS mede-se (§0)
 
 > **Observabilidade** (opcional, depende da stack): se o projeto usa error tracking (ex: Sentry) ou logging estruturado, confirmar que erros de UI sao capturados. Nao assumir um vendor.
 

--- a/.agent/workflows/review.md
+++ b/.agent/workflows/review.md
@@ -58,6 +58,7 @@ Checklist de revisao de codigo antes de fazer commit no {{PROJECT_NAME}}.
 ## 6. Arquitetura
 
 - [ ] Ficheiros com menos de ~400 linhas (flag se > 500)
+- [ ] **Diff minimo**: nenhuma reformatacao de codigo que o ticket nao toca — `git diff --stat` proporcional a alteracao (`core-rules.md`)
 - [ ] Parent detem estado, sub-components recebem props
 - [ ] Nomes de componentes descritivos
 - [ ] One-time form init usa guard `initialized` para evitar resets por revalidation


### PR DESCRIPTION
## Summary

Read a project built from this template and compared what each side had learned. Neither
version of the per-ticket method was strictly better — the template had gained structure, the
project had kept the scars. Four things came back:

- **The error-to-rule table** — each rule paired with the failure that produced it. Rows marked `T` (this repo) or `P` (the derived project), half and half.
- **"Do not reformat what the ticket does not touch"** — a rule the template did not have at all. `npx prettier` in a repo without prettier inflated a one-line diff to `+225/-99`.
- **A cost section** — Fase 4 quantified with this repo's own measurement: ~168k tokens, 16 minutes, three high findings six of my own passes had missed.
- **What a design harness must measure** — `design-review.md` admitted it had "no automated harness". The transferable part is the specification, not the code.

## Changes

- `.agent/rules/ticket-method.md` — the error-to-rule table and a cost section.
- `.agent/rules/core-rules.md` — the minimal-diff rule; paid for by cutting a Tags paragraph duplicated verbatim with `process-rules.md` (both always loaded, so nothing lost).
- `.agent/workflows/design-review.md` — new §0: the four measurable criteria and, for each, the pitfall that yields a confidently **false** result. Reading `oklch` as RGB gave five false contrast positives; `document.scrollWidth` claims no overflow when the body hides it; measuring CLS before fonts settle reads optimistically.
- `.agent/workflows/review.md` — checks the minimal diff.

## Test Plan

```
node .agent/scripts/check-doc-versions.mjs   # 0 — includes the four derived-count guards
node .agent/scripts/check-backlog.mjs        # 0
the four suites                              # 201 tests
node .agent/scripts/mutation-sweep.mjs       # 90/90, eight targets
```

No script changed in this round, so the sweep measures the same code. Also verified that all
ten `§N` cross-references resolve to sections that exist — nothing guards that, so it was
checked by hand.

**Two errors of my own, both found by reading the new text end to end rather than by any
tool**: the table header claimed every row happened "in this repo" when half did not (a
`toHaveCount(0)` assertion cannot have — this repo has no Playwright), and the note about
which two measurements were wrong pointed at rows 1 and 2 when it was rows 1 and 4. Worth
noting because it is the third time this branch has found a false claim in prose I had just
written, and the tooling cannot catch that class.

## Checklist

> **Nota**: repo do template — sem `package.json` nem app, logo `tsc`/`lint`/`build`/`test`/`audit`
> nao se aplicam. Guards, doc sync e secrets corridos.

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] Bundle sizes within targets (if configured — `node .agent/scripts/check-bundle-sizes.mjs`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] E2E tests pass (`npm run test`)
- [ ] Security tests pass (`npm run test:security`)
- [ ] Dependency audit reviewed (`npm run test:audit`) — it is informative in CI, so green does not mean clean
- [ ] Doc guards pass (`node .agent/scripts/check-doc-versions.mjs`) — no WARN
- [ ] If `.agent/scripts/` changed: guard tests pass (`test-guards.mjs`, `test-bundle-sizes.mjs`, `test-backlog.mjs`, `test-mutation-sweep.mjs`)
- [ ] If a `check-*.mjs` changed: `node .agent/scripts/mutation-sweep.mjs` exits 0 (every warning site goes red; no checker without a suite)
- [ ] Backlog counters valid (`node .agent/scripts/check-backlog.mjs`) — 0 divergences
- [ ] CI is green on the branch — never merge on red, and **check that checks exist**: `gh pr checks --watch` exits 0 when none have been reported yet
- [ ] `src/docs/CHANGELOG.md` updated
- [ ] `.agent/context/backlog.md` updated (if applicable)
- [ ] No secrets or credentials in committed files
- [ ] **L ticket, or touches the core domain?** Independent reader ran (Fase 4 — the
      `code-reviewer` subagent, or a separate session given only the diff), each finding
      **verified against the real file**, and CONFIRMED vs PLAUSIBLE stated. It reads code;
      it is not a substitute for the `/review` passes above

