### PR TITLE
fix(guards): close what an independent review of the whole session found

### DIFF
--- a/.agent/BOOTSTRAP.md
+++ b/.agent/BOOTSTRAP.md
@@ -142,7 +142,7 @@ Guarda as respostas — vais precisar delas para preencher todos os placeholders
 Antes das perguntas de stack, decidir com o utilizador a **dimensao do processo**:
 
 - **Projeto pequeno / prototipo / fim-de-semana** → **Modo minimo**: manter so os workflows essenciais (`plan`, `review`, `debug`, `deploy`) e **remover os restantes** (`refactor`, `e2e-tests`, `security-tests`, `design-review`, `audit`, `market-scan`, `setup`) na Fase 2 — ver §2.6. Menos cerimonia, menos ficheiros a manter.
-- **Projeto sustentado / produto / equipa** → **Modo completo** (default do template): manter os 11 workflows + ritual de backlog/sprint + guards.
+- **Projeto sustentado / produto / equipa** → **Modo completo** (default do template): manter os 12 workflows + ritual de backlog/sprint + guards.
 
 > Registar a escolha; ela determina a poda de workflows na Fase 2 (§2.6). Adicionar workflows mais tarde e trivial (Matriz de Propagacao em `sync-docs.md`). Na duvida, comecar no Modo minimo — expandir e barato, podar depois e chato.
 
@@ -312,7 +312,7 @@ const TARGETS = {
 
 ### 2.4 Configurar os Doc Guards
 
-O `.agent/scripts/check-doc-versions.mjs` corre **sem configuracao** 14 guards numerados. O total que ele reporta como "executados" **nao e um numero fixo** e nao vale a pena decora-lo: o Guard 1 conta uma vez por rule obrigatoria, os Guards 3 e 4 saltam sem `package.json`/`BANNED`, e cada `CHECK` configurado soma um. Correr e ler o que ele diz; o que importa e o exit code e a ausencia de `WARN`. Os guards sao: orcamento de bytes das rules, paridade `CLAUDE.md`≡`GEMINI.md`, versao `package.json`≡`CHANGELOG`, termos obsoletos, `.nvmrc`, paridade workflows↔wrappers (existencia **e** conteudo do ponteiro), workflows listados em `CLAUDE`/`GEMINI`/`AGENTS`/`agent-guide`, `@imports` que resolvem, e sanidade do `.claude/settings.json`.
+O `.agent/scripts/check-doc-versions.mjs` corre **sem configuracao** 16 guards numerados. O total que ele reporta como "executados" **nao e um numero fixo** e nao vale a pena decora-lo: o Guard 1 conta uma vez por rule obrigatoria, os Guards 3 e 4 saltam sem `package.json`/`BANNED`, e cada `CHECK` configurado soma um. Correr e ler o que ele diz; o que importa e o exit code e a ausencia de `WARN`. Os guards sao: orcamento de bytes das rules, paridade `CLAUDE.md`≡`GEMINI.md`, versao `package.json`≡`CHANGELOG`, termos obsoletos, `.nvmrc`, paridade workflows↔wrappers (existencia **e** conteudo do ponteiro), workflows listados em `CLAUDE`/`GEMINI`/`AGENTS`/`agent-guide`, `@imports` que resolvem, e sanidade do `.claude/settings.json`.
 
 > **Os guards tem os seus proprios testes.** `node .agent/scripts/test-guards.mjs`,
 > `test-bundle-sizes.mjs` e `test-backlog.mjs` quebram cada guard de proposito e exigem que

--- a/.agent/rules/anti-patterns.md
+++ b/.agent/rules/anti-patterns.md
@@ -61,6 +61,21 @@
   identico ao da raiz) e **num clone com CRLF** (`core.autocrlf=true` em Windows): um patch
   ou regex com `"\n"` literal deixa de casar e o teste passa a nao afirmar nada.
 
+## AP3 — Teste que depende do estado do repo em vez de o montar
+
+- **Origem**: o teste do Guard 13 neste template.
+- **Anti-padrao**: uma assercao que so e verdadeira no estado **atual** do repo, sem a fixture
+  a montar essa condicao. O teste do Guard 13 afirmava que ele **salta**, passando `null` como
+  mutacao — verdade no template nu, onde o ficheiro que dispara o guard nao existe, e **falsa
+  em qualquer projeto derivado**, onde o bootstrap o cria. A suite passava aqui e falhava no
+  primeiro dia de cada consumidor.
+- **Correto**: a fixture **cria ou apaga** aquilo de que a assercao depende. Se o teste precisa
+  que um ficheiro nao exista, apaga-o; se precisa que exista, escreve-o. Nunca herdar do repo.
+- **Detecao em review**: procurar testes com mutacao vazia — `grep -n 'test(.*, null,' <suite>`
+  — e, por cada um, perguntar _"o que e que isto assume sobre o repo?"_. E, sobretudo: correr a
+  suite num **projeto derivado** e nao so no template. Um teste verde num sitio e vermelho no
+  outro nao esta a afirmar o que diz.
+
 > Esta entrada vem do template. Aplica-se a qualquer projeto que escreva testes de
 > verificadores; se o teu projeto nao tiver nenhum, podes substitui-la pela primeira que
 > um bug teu revelar.

--- a/.agent/scripts/check-doc-versions.mjs
+++ b/.agent/scripts/check-doc-versions.mjs
@@ -109,7 +109,10 @@ const RULES_MAX_BYTES = 12000;
 function checkRuleBytes(file) {
   const content = read(file);
   if (content === null) return null;
-  const bytes = Buffer.byteLength(content, "utf8");
+  // Normalizar CRLF antes de medir: um clone com `core.autocrlf=true` acrescenta um byte por
+  // linha, e `process-rules.md` mudava de OK para NOTE so por isso — o gate passava a depender
+  // da plataforma de quem o corre em vez do conteudo. Este e o numero que o agente carrega.
+  const bytes = Buffer.byteLength(content.replace(/\r\n/g, "\n"), "utf8");
   if (content.trim() === "") {
     warn(`${file} = ${bytes} bytes mas esta VAZIO — e uma rule importada em CLAUDE.md/GEMINI.md`);
     return bytes;

--- a/.agent/scripts/guards/derived-counts.mjs
+++ b/.agent/scripts/guards/derived-counts.mjs
@@ -24,6 +24,10 @@ function ficheirosComProsa(listDir) {
     "AGENTS.md",
     "README.md",
     "CONTRIBUTING.md",
+    // O `BOOTSTRAP.md` entra na lista COMUM: o 12d ja o acrescentava com um `.concat()` a
+    // parte e o 12e nao, logo uma citacao do numero de workflows ali passava. Unificado para
+    // os quatro guards varrerem o mesmo conjunto.
+    ".agent/BOOTSTRAP.md",
   ];
 }
 
@@ -150,7 +154,7 @@ if (metodo) {
 }
 
 
-  // --- 12d: o numero de guards numerados e dado DERIVADO ---
+  // --- Guard 12d: o numero de guards numerados e dado DERIVADO ---
   // Terceira instancia do mesmo padrao (checklist, fases, e agora isto): o `BOOTSTRAP.md`
   // dizia "11 guards numerados" quando existiam 14. O numero era mantido a mao.
   const fontes = [
@@ -161,14 +165,17 @@ if (metodo) {
   for (const f of fontes) {
     const c = read(f);
     if (c === null) continue;
-    for (const m of c.matchAll(/^\/\/ --- Guard (\d+[a-z]?):/gm)) numerados.add(m[1]);
+    // `^\\s*` e `(?:Guard )?`: a versao anterior exigia coluna 0 e a palavra "Guard", logo o
+    // proprio 12d (indentado, escrito `// --- Guard 12d:`) nao se contava, e reindentar um
+    // cabecalho — a limpeza obvia depois do refactor verbatim — derrubava a contagem.
+    for (const m of c.matchAll(/^\s*\/\/ --- (?:Guard )?(\d+[a-z]?):/gm)) numerados.add(m[1]);
   }
   if (numerados.size === 0) {
     warn("nao encontrei nenhum cabecalho `// --- Guard N:` — os guards mudaram de formato?");
   } else {
     let cit = 0;
     let mal = 0;
-    for (const f of ficheirosComProsa(listDir).concat([".agent/BOOTSTRAP.md"])) {
+    for (const f of ficheirosComProsa(listDir)) {
       const c = read(f);
       if (c === null) continue;
       for (const linha of c.split("\n")) {
@@ -181,7 +188,42 @@ if (metodo) {
         }
       }
     }
-    if (cit > 0 && mal === 0) ok(`${cit} citacao(oes) de "N guards numerados" coerentes com ${numerados.size}`);
+    if (cit === 0) {
+      // Os guards 12b e 12c tem este ramo; o 12d nao tinha, logo apagar a citacao fazia o
+      // guard passar em silencio — sem OK e sem WARN — enquanto `guardsRun` continuava a
+      // contar. Um guard que nao verifica nada tem de o dizer.
+      warn("nenhum ficheiro cita o numero de guards numerados — a referencia desapareceu?");
+    } else if (mal === 0) {
+      ok(`${cit} citacao(oes) de "N guards numerados" coerentes com ${numerados.size}`);
+    }
+  }
+  guardsRun++;
+
+  // --- Guard 12e: o numero de workflows/comandos e dado DERIVADO ---
+  // Quarta instancia do padrao. `11 workflows` e `11 commands` ficaram atras quando o
+  // `/upgrade` fez 12 — e o numero ja estava calculado nos guards 6/7/9, so nao era comparado
+  // com a prosa.
+  const nWorkflows = (listDir(".agent/workflows", ".md") || []).length;
+  if (nWorkflows === 0) {
+    warn("nao encontrei workflows em .agent/workflows — a pasta mudou de sitio?");
+  } else {
+    let cit = 0;
+    let mal = 0;
+    for (const f of ficheirosComProsa(listDir)) {
+      const c = read(f);
+      if (c === null) continue;
+      for (const linha of c.split("\n")) {
+        const m = /(\d+)\s+(workflows|comandos|commands)\b/i.exec(linha);
+        if (!m) continue;
+        cit++;
+        if (Number(m[1]) !== nWorkflows) {
+          warn(`${f} diz "${m[1]} ${m[2]}" mas existem ${nWorkflows} workflows`);
+          mal++;
+        }
+      }
+    }
+    if (cit === 0) warn("nenhum ficheiro cita o numero de workflows — a referencia desapareceu?");
+    else if (mal === 0) ok(`${cit} citacao(oes) de "N workflows/comandos" coerentes com ${nWorkflows}`);
   }
   guardsRun++;
 

--- a/.agent/scripts/guards/placeholders.mjs
+++ b/.agent/scripts/guards/placeholders.mjs
@@ -21,10 +21,13 @@
 // `.agent/BOOTSTRAP.md` e `README.md` DOCUMENTAM os placeholders — citam-nos por design.
 const DOCUMENTAM = new Set([".agent/BOOTSTRAP.md", "README.md"]);
 
-// Falsos positivos que nao sao placeholders do template:
-//   `${{ ... }}`  expressoes do GitHub Actions
-//   `{{args}}`    argumentos dos command templates do Gemini
-const FALSOS = /\$\{\{[^}]*\}\}|\{\{args\}\}/g;
+// Falsos positivos: expressoes do GitHub Actions, `${{ ... }}`. O caso que importa e
+// `${{VAR}}` — maiusculas, sem espacos e sem ponto — porque e o unico que o padrao de
+// placeholder abaixo tambem casaria. Formas como `${{ secrets.TOKEN }}` nunca casariam
+// (tem ponto e espacos), logo nao dependem desta constante.
+// A alternativa `{{args}}` dos command templates do Gemini foi removida por ser morta:
+// `PLACEHOLDER` so casa `[A-Z_]+` e `args` e minusculo.
+const FALSOS = /\$\{\{[^}]*\}\}/g;
 
 const PLACEHOLDER = /\{\{([A-Z_]+)\}\}/g;
 
@@ -47,6 +50,11 @@ export function guardPlaceholders({ read, warn, ok, skip, listDir }) {
     "LICENSE",
     ".github/CODEOWNERS",
     ".github/pull_request_template.md",
+    // Estes dois entram nos alvos DE PROPOSITO: sem eles na lista, o filtro `DOCUMENTAM`
+    // nunca corria (0 execucoes em 146 testes) e o teste que dizia cobri-lo passava porque
+    // os ficheiros nunca eram lidos — AP1. Agora o filtro e que os exclui, e isso e testavel.
+    ".agent/BOOTSTRAP.md",
+    "README.md",
     // Pontos de entrada que o Copilot e o Cursor carregam. Nao estavam aqui quando foram
     // criados, logo um placeholder esquecido neles passava — e sao os primeiros ficheiros
     // que essas ferramentas leem.

--- a/.agent/scripts/mutation-sweep.mjs
+++ b/.agent/scripts/mutation-sweep.mjs
@@ -28,7 +28,7 @@
  *   node .agent/scripts/mutation-sweep.mjs --only=backlog     # so um (ao mexer nele)
  *   node .agent/scripts/mutation-sweep.mjs --list             # so contar, sem correr
  *
- * CUSTO: recorre a suite inteira por sitio. ~50 sitios = minutos. Correr apos mexer num
+ * CUSTO: recorre a suite inteira por sitio. dezenas de sitios = minutos. Correr apos mexer num
  * verificador, nao a cada commit. Opt-in no CI (ver `.github/workflows/ci.yml`).
  */
 
@@ -39,6 +39,15 @@ import { fileURLToPath } from "url";
 import { dirname, resolve, join } from "path";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Lista os ficheiros de uma pasta do repo; `[]` se nao existir. */
+function listarDir(rel) {
+  try {
+    return readdirSync(join(ROOT, rel), { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
 
 // Cada verificador tem de ter a sua suite E declarar como sinaliza um problema — nem todos
 // sinalizam da mesma forma, e um regex global daria "0 sitios, nada a varrer" a um
@@ -132,6 +141,28 @@ const onlyArg = process.argv.find((a) => a.startsWith("--only="));
 const only = onlyArg ? onlyArg.slice("--only=".length) : null;
 
 let falhou = false;
+
+// DESCOBERTA: `PARES` e mantido a mao, logo um verificador novo entrava no repo sem rede
+// nenhuma — e a documentacao afirmava, em quatro sitios, que a varredura o detetava. Nao
+// detetava: o ramo `SEM SUITE` so dispara para uma entrada de `PARES` com `suite` nula, o que
+// exige que alguem a tenha acrescentado. Isto varre o disco e reprova o que nao esta na lista.
+// E o mesmo raciocinio do `ALVO AUSENTE`, na direcao inversa.
+if (!only) {
+  const noDisco = [
+    // A convencao do repo: verificadores sao `check-*.mjs` e os seus modulos vivem em
+    // `guards/`. Este ficheiro nao entra na descoberta — ja esta em `PARES`, e incluir-se
+    // fazia a sua propria fixture de teste (que substitui `PARES`) reprovar.
+    ...listarDir(".agent/scripts").filter((f) => /^check-.*\.mjs$/.test(f)).map((f) => `.agent/scripts/${f}`),
+    ...listarDir(".agent/scripts/guards").filter((f) => f.endsWith(".mjs")).map((f) => `.agent/scripts/guards/${f}`),
+  ];
+  const registados = new Set(PARES.map((p) => p.alvo));
+  for (const f of noDisco) {
+    if (!registados.has(f)) {
+      console.log(`  SEM PAR  ${f} nao esta em PARES — verificador novo entra sem rede nenhuma`);
+      falhou = true;
+    }
+  }
+}
 
 const selecionados = only ? PARES.filter((p) => p.alvo.includes(only)) : PARES;
 if (only && selecionados.length === 0) {

--- a/.agent/scripts/test-guards.mjs
+++ b/.agent/scripts/test-guards.mjs
@@ -100,9 +100,14 @@ test("cwd: [controlo negativo] com ROOT = cwd, o guard TEM de falhar", (dir) => 
 });
 
 // --- Guard 1: orcamento de bytes e rules obrigatorias -------------------------
+// `synthetic: true`: a fixture sintetica escreve rules minimas, logo o aviso de orcamento e
+// genuinamente NOVO. Com a copia do repo, um projeto derivado cujas rules ja excedam o limite
+// — o `core-rules.md` do template esta a 11507 de 12000 e o template manda-lhe acrescentar
+// regras de dominio — ja tem esse aviso no baseline, e a assercao diferencial (corretamente)
+// nao ve nada de novo. O teste falhava sem que nada estivesse errado.
 test("G1: rule acima do maximo de bytes avisa", (dir) => {
-  appendFileSync(file(dir, ".agent/rules/core-rules.md"), "x".repeat(5000));
-}, { code: 1, includes: ["core-rules.md", "bytes >"] });
+  appendFileSync(file(dir, ".agent/rules/core-rules.md"), "x".repeat(15000));
+}, { code: 1, synthetic: true, includes: ["core-rules.md", "bytes >"] });
 
 test("G1: rule obrigatoria ausente avisa (nao passa em silencio)", (dir) => {
   rmSync(file(dir, ".agent/rules/anti-patterns.md"));
@@ -185,9 +190,17 @@ test("G4: termo banido e apanhado em TODOS os ficheiros, nao so no primeiro", (d
   writeF(dir, GUARD, g);
 }, { code: 1, includes: ["CLAUDE.md:", "GEMINI.md:", "termo de teste"] });
 
-test("G4: lista BANNED vazia da SKIP visivel", null, {
+// A fixture ESVAZIA o `BANNED`, em vez de assumir que o repo o tem vazio: um projeto
+// derivado que use a feature (e ela existe para isso) tornava esta pre-condicao falsa — AP3.
+test("G4: lista BANNED vazia da SKIP visivel", (dir) => {
+  const g = readF(dir, GUARD).replace(/const BANNED = \[[\s\S]*?\];/, "const BANNED = [];");
+  if (g === readF(dir, GUARD)) throw new Error("nao encontrei o array BANNED no GUARD");
+  writeF(dir, GUARD, g);
+}, {
   code: 0,
-  includes: ["SKIP  Guard 4"],
+  // A mensagem INTEIRA, e nao o prefixo `SKIP  Guard 4`: o guard tem um segundo skip
+  // ("Guard 4 em <ficheiro> — ficheiro nao encontrado") que satisfazia a assercao sozinho.
+  includes: ["SKIP  Guard 4 (termos banidos) — lista BANNED vazia"],
 });
 
 // --- Guard 5: .nvmrc ----------------------------------------------------------

--- a/.agent/scripts/test-harness.mjs
+++ b/.agent/scripts/test-harness.mjs
@@ -60,6 +60,10 @@ const FIXTURE_PATHS = [
   ".cursor/rules",
   ".github/copilot-instructions.md",
   ".gemini/commands",
+  // O `README.md` e um dos `LIVING_DOCS` do Guard 4. Sem ele na fixture, o guard emitia um
+  // skip de "ficheiro nao encontrado" a cada corrida e nunca varria um dos seis ficheiros
+  // que promete varrer.
+  "README.md",
   "CLAUDE.md",
   "GEMINI.md",
   "AGENTS.md",
@@ -170,8 +174,19 @@ function test(name, mutate, expect) {
     for (const s of expect.anyOut ?? []) {
       if (!out.includes(s)) problems.push(`output devia conter "${s}"`);
     }
+    // `excludes` tambem tem de ser DIFERENCIAL, pela mesma razao que o `includes`: era
+    // testado contra o output absoluto, logo um WARN de baseline sem relacao nenhuma —
+    // por exemplo o orcamento de bytes num projeto que acrescentou regras de dominio as
+    // rules, que e o uso normal — fazia falhar testes de CRLF e de placeholders, apontando
+    // o diagnostico para o sitio errado. Uma linha que ja estava no baseline nao e culpa
+    // desta mutacao.
     for (const s of [...(expect.excludes ?? []), ...(extra.excludes ?? [])]) {
-      if (out.includes(s)) problems.push(`output NAO devia conter "${s}"`);
+      if (!out.includes(s)) continue;
+      const novaOcorrencia = out
+        .split("\n")
+        .filter((l) => l.includes(s))
+        .some((l) => !base.has(chaveWarn(l)));
+      if (novaOcorrencia) problems.push(`output NAO devia conter "${s}" (ocorrencia nova, nao de baseline)`);
     }
     if (problems.length) {
       failures.push({ name, problems, out });
@@ -225,6 +240,15 @@ function syntheticSandbox() {
   for (const r of ["core-rules", "process-rules", "anti-patterns"]) {
     w(`.agent/rules/${r}.md`, `# ${r}\n\nConteudo minimo.\n`);
   }
+  // O `BOOTSTRAP.md` da fixture cita as contagens que os guards 12d/12e recalculam. Os
+  // numeros sao DERIVADOS do que esta fixture acabou de copiar/escrever — fixa-los aqui
+  // envelheceria a cada guard ou workflow novo, que e o defeito que esses guards existem
+  // para apanhar.
+  const nGuards = new Set(
+    [GUARD, ...(existsSync(join(ROOT, GUARD_MODULES)) ? readdirSync(join(ROOT, GUARD_MODULES)).map((f) => `${GUARD_MODULES}/${f}`) : [])]
+      .flatMap((f) => [...readFileSync(join(ROOT, f), "utf8").matchAll(/^\s*\/\/ --- (?:Guard )?(\d+[a-z]?):/gm)].map((m) => m[1]))
+  ).size;
+  w(".agent/BOOTSTRAP.md", `# Bootstrap\n\nO checker corre ${nGuards} guards numerados.\nO template traz 1 workflows.\n`);
   w(".agent/workflows/plan.md", "# /plan\n");
   w(".claude/commands/plan.md", "---\ndescription: x\n---\n\nLer `.agent/workflows/plan.md`.\n");
   w(".gemini/commands/plan.toml", 'description = "x"\nprompt = "Le .agent/workflows/plan.md"\n');
@@ -269,8 +293,18 @@ console.log("\n=== Testes dos Doc Guards ===\n");
 // saltar testes quando nao esta), captura-se o conjunto de WARN do baseline UMA vez e
 // tudo se afirma por diferenca. Assim os 64 testes correm sempre e o veredicto e sobre
 // o guard, nao sobre o estado do repo.
+/** Chave de comparacao de um aviso, com os NUMEROS normalizados.
+ *
+ *  Sem isto, a comparacao diferencial era fragil a qualquer mensagem que carregue um numero:
+ *  um teste que acrescenta bytes a uma rule muda o aviso do orcamento de `= 12868 bytes` para
+ *  `= 12915 bytes`, e o texto exato deixava de casar o baseline — o aviso aparecia como NOVO e
+ *  o teste falhava a apontar para o sitio errado (foi o que quebrou quatro testes de CRLF e de
+ *  placeholders num projeto com rules maiores, que e o uso normal).
+ *
+ *  O que se quer saber e se apareceu um aviso de tipo NOVO, nao se um numero mudou de valor. */
+const chaveWarn = (l) => l.trim().replace(/\d+/g, "N");
 const warnsOf = (out) =>
-  new Set(out.split("\n").filter((l) => l.trimStart().startsWith("WARN")).map((l) => l.trim()));
+  new Set(out.split("\n").filter((l) => l.trimStart().startsWith("WARN")).map(chaveWarn));
 let baselineWarns;
 let syntheticBaselineWarns;
 {

--- a/.agent/scripts/test-mutation-sweep.mjs
+++ b/.agent/scripts/test-mutation-sweep.mjs
@@ -53,7 +53,7 @@ if (r.code === 0 || !r.out.includes("encontrei 'mau'")) { console.log("FALHOU");
 console.log("ok");
 `;
 
-function sandbox({ suite = ".agent/scripts/fake-test.mjs", sinal = "/(?<![\\w.$])warn\\(/", segundoSitio = true, baselineVermelha = false, semAlvo = false, opcional = false, doisNaMesmaLinha = false } = {}) {
+function sandbox({ suite = ".agent/scripts/fake-test.mjs", sinal = "/(?<![\\w.$])warn\\(/", segundoSitio = true, baselineVermelha = false, semAlvo = false, opcional = false, doisNaMesmaLinha = false, verificadorSemPar = false } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "sweep-test-"));
   mkdirSync(join(dir, ".agent/scripts"), { recursive: true });
 
@@ -73,6 +73,11 @@ function sandbox({ suite = ".agent/scripts/fake-test.mjs", sinal = "/(?<![\\w.$]
     );
   }
   if (!semAlvo) writeFileSync(join(dir, ".agent/scripts/fake-check.mjs"), check);
+  if (verificadorSemPar) {
+    // Nome que casa a convencao `check-*.mjs` e ausente de `PARES`: e o cenario de alguem
+    // acrescentar um verificador ao repo e esquecer o registo.
+    writeFileSync(join(dir, ".agent/scripts/check-orfao.mjs"), 'const warn=(m)=>console.log(m);\nif(process.env.X)warn("a");\n');
+  }
 
   writeFileSync(
     join(dir, ".agent/scripts/fake-test.mjs"),
@@ -200,6 +205,21 @@ test("dois avisos na mesma linha reprovam em vez de herdar cobertura",
   includes: ["LINHA AMBIGUA", "2 avisos na mesma linha", "separa-los para cada um ser medido"],
   // Sem INCOMPLETA no output, a LINHA AMBIGUA e a unica coisa que pode fazer o exit != 0.
   excludes: ["Cobertura de mutacao completa", "INCOMPLETA  .agent"],
+});
+
+// --- Verificador no disco e ausente de PARES (achado da Fase 4) --------------
+// A documentacao afirmava, em quatro sitios, que a varredura reprovava um verificador sem
+// suite. Nao reprovava: o ramo `SEM SUITE` so dispara para uma entrada de `PARES` com
+// `suite` nula, o que exige que alguem a tenha acrescentado. Um `check-*.mjs` novo entrava
+// no repo sem rede e a prosa garantia o contrario.
+test("verificador no disco e ausente de PARES reprova", { verificadorSemPar: true }, ["--list"], {
+  code: 1,
+  includes: ["SEM PAR", "check-orfao.mjs", "sem rede nenhuma"],
+});
+
+test("com todos os verificadores registados, nao ha SEM PAR", {}, ["--list"], {
+  code: 0,
+  excludes: ["SEM PAR"],
 });
 
 // --- Contratos que nao se podem perder ---------------------------------------

--- a/.agent/scripts/tests-derived-counts.mjs
+++ b/.agent/scripts/tests-derived-counts.mjs
@@ -7,7 +7,8 @@
  * NAO e um entry point: o `test-guards.mjs` importa e chama `registar()`, para a ordem dos
  * testes ser explicita em vez de depender da ordem de avaliacao dos imports.
  */
-import { rmSync } from "fs";
+import { readdirSync, rmSync } from "fs";
+import { join } from "path";
 import { pathToFileURL } from "url";
 import { test, file, readF, writeF } from "./test-harness.mjs";
 
@@ -127,7 +128,35 @@ test("G12c: metodo ausente da SKIP visivel, nao silencio", (dir) => {
     for (const f of ["check-doc-versions.mjs", "guards/settings.mjs", "guards/versions.mjs",
                      "guards/derived-counts.mjs", "guards/placeholders.mjs"]) {
       writeF(dir, `.agent/scripts/${f}`,
-        readF(dir, `.agent/scripts/${f}`).replace(/^\/\/ --- Guard (\d+[a-z]?):/gm, "// --- Verificacao:"));
+        readF(dir, `.agent/scripts/${f}`).replace(/^\s*\/\/ --- (?:Guard )?(\d+[a-z]?):/gm, "// --- Verificacao:"));
     }
   }, { code: 1, includes: ["nao encontrei nenhum cabecalho"] });
+
+  // --- 12d: citacao apagada (o ramo que faltava) -----------------------------
+  // Os guards 12b/12c avisam quando `citacoes === 0`; o 12d nao tinha esse ramo, logo
+  // apagar a citacao fazia-o passar em silencio — sem OK e sem WARN — enquanto `guardsRun`
+  // continuava a conta-lo. Achado da Fase 4.
+  test("G12d: citacao do numero de guards apagada avisa", (dir) => {
+    writeF(dir, ".agent/BOOTSTRAP.md",
+      readF(dir, ".agent/BOOTSTRAP.md").replace(/\d+ guards numerados/, "muitos guards"));
+  }, { code: 1, includes: ["nenhum ficheiro cita o numero de guards numerados"] });
+
+  // --- 12e: contagem de workflows/comandos ----------------------------------
+  // Quarta instancia do padrao: "11 workflows" e "11 commands" ficaram atras quando o
+  // /upgrade fez 12. O numero ja estava calculado nos guards 6/7/9, so nao era comparado.
+  test("G12e: citacao desatualizada do numero de workflows avisa", (dir) => {
+    writeF(dir, "README.md", readF(dir, "README.md") + "\n\nO template traz 99 workflows.\n");
+  }, { code: 1, includes: ['diz "99 workflows" mas existem'] });
+
+  test("G12e: citacao apagada avisa", (dir) => {
+    for (const f of ["README.md", ".agent/BOOTSTRAP.md"]) {
+      writeF(dir, f, readF(dir, f).replace(/(\d+)\s+(workflows|comandos|commands)\b/gi, "os workflows"));
+    }
+  }, { code: 1, includes: ["nenhum ficheiro cita o numero de workflows"] });
+
+  test("G12e: pasta de workflows vazia avisa", (dir) => {
+    for (const f of readdirSync(join(dir, ".agent/workflows"))) {
+      if (f.endsWith(".md")) rmSync(join(dir, ".agent/workflows", f));
+    }
+  }, { code: 1, includes: ["nao encontrei workflows em .agent/workflows"] });
 }

--- a/.agent/scripts/tests-placeholders.mjs
+++ b/.agent/scripts/tests-placeholders.mjs
@@ -7,10 +7,10 @@
  * A fixture tem de simular um projeto JA bootstrapado, senao o guard salta — e um teste que
  * passa por o guard nao correr nao afirma nada.
  */
-import { readdirSync } from "fs";
+import { readdirSync, rmSync } from "fs";
 import { join } from "path";
 import { pathToFileURL } from "url";
-import { test, readF, writeF } from "./test-harness.mjs";
+import { test, readF, writeF, file } from "./test-harness.mjs";
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.error(
@@ -50,7 +50,18 @@ const bootstrapado = (dir) => {
 
 export function registar() {
   // --- Guard 13: placeholders esquecidos -------------------------------------
-  test("G13: sem bootstrap da SKIP visivel (placeholders sao esperados)", null, {
+  // O teste controla a sua PROPRIA pre-condicao: apaga o `business-logic.md` da fixture.
+  // A versao anterior passava `null` como mutacao e assumia que o ficheiro nao existia —
+  // verdade no template nu, **falsa em qualquer projeto derivado**, onde o bootstrap o gera.
+  // Resultado: a suite passava aqui e falhava no primeiro dia de cada consumidor. Um teste
+  // que depende do ambiente em vez de o montar nao esta a afirmar o que diz.
+  test("G13: sem bootstrap da SKIP visivel (placeholders sao esperados)", (dir) => {
+    try {
+      rmSync(file(dir, ".agent/rules/business-logic.md"));
+    } catch {
+      /* no template nu ja nao existe — e o estado que este teste quer */
+    }
+  }, {
     code: 0,
     includes: ["SKIP  Guard 13 (placeholders) — bootstrap ainda nao correu"],
   });
@@ -85,8 +96,10 @@ export function registar() {
   test("G13: BOOTSTRAP.md e README.md documentam placeholders e nao contam", (dir) => {
     bootstrapado(dir);
     // Estes dois citam `{{...}}` por design; se contassem, todo projeto derivado avisaria.
+    // ACRESCENTAR, nao substituir: reescrever o `BOOTSTRAP.md` apagava as citacoes que os
+    // guards 12d/12e verificam, e o teste falhava por um aviso sem relacao com o Guard 13.
     for (const f of [".agent/BOOTSTRAP.md", "README.md"]) {
-      try { writeF(dir, f, `# doc\n\nSubstituir ${ph("HOSTING")} e ${ph("YEAR")}.\n`); } catch {}
+      try { writeF(dir, f, readF(dir, f) + `\n\nSubstituir ${ph("HOSTING")} e ${ph("YEAR")}.\n`); } catch {}
     }
   }, { code: 0, includes: ["sem placeholders esquecidos"], excludes: ["  WARN  "] });
 }

--- a/.agent/workflows/upgrade.md
+++ b/.agent/workflows/upgrade.md
@@ -20,6 +20,10 @@ nenhum. Apresentar sempre: o que se traz, o que se ignora, e o diff de tudo o qu
 cat .agent/.template-version 2>/dev/null || echo "SEM MARCA"
 ```
 
+> **E preciso um clone local do template.** Os comandos abaixo usam `git -C "$TPL"` ou
+> `cd "$TPL"`, que exigem um **diretorio** — uma URL falha com `cannot change to '...'`. Se so
+> tiveres a URL: `git clone <url> /tmp/tpl && TPL=/tmp/tpl`.
+
 Isto decide o modo. Os dois sao validos; o segundo e o normal em projetos criados antes de a
 marca existir.
 
@@ -28,10 +32,13 @@ marca existir.
 O ficheiro traz o commit do template de onde este projeto nasceu (ou da ultima atualizacao).
 
 ```bash
-TPL=<caminho-ou-url-do-template>
+TPL=<caminho-para-um-CLONE-LOCAL-do-template>
 SHA=$(grep -oE '\b[0-9a-f]{7,40}\b' .agent/.template-version | head -1)
-git -C "$TPL" log --oneline "$SHA"..main          # o que mudou desde entao
-git -C "$TPL" diff --stat "$SHA"..main            # e em que ficheiros
+# Sem baseline NAO se faz diff — cai-se no Modo B em vez de comparar contra `HEAD` por acidente.
+: "${SHA:?marca ilegivel — usar o Modo B}"
+BR=$(git -C "$TPL" symbolic-ref --short HEAD)
+git -C "$TPL" log --oneline "$SHA".."$BR"          # o que mudou desde entao
+git -C "$TPL" diff --stat "$SHA".."$BR"            # e em que ficheiros
 ```
 
 Trabalhar **so** sobre esses ficheiros. E o modo preciso: nao propoe nada que o projeto ja
@@ -46,7 +53,7 @@ Em vez disso, **detetar capacidades**: por cada coisa que o template tem, verifi
 projeto a tem, e so entao propor. Perguntas em vez de diffs:
 
 ```bash
-TPL=<caminho-ou-url-do-template>
+TPL=<caminho-para-um-CLONE-LOCAL-do-template>
 # 1. Que ficheiros o template tem que este projeto nao tem?
 (cd "$TPL" && git ls-files) | while read -r f; do [ -e "$f" ] || echo "AUSENTE: $f"; done
 # 2. Que scripts de verificacao existem em cada lado?
@@ -63,7 +70,7 @@ O que esta **ausente** e candidato a copia. O que existe nos dois vai para a tab
 | Categoria | O que fazer | Porque |
 |-----------|-------------|--------|
 | `.agent/context/*`, `src/docs/CHANGELOG.md` | **NUNCA tocar** | E o estado e a historia deste projeto. Nao existem em mais sitio nenhum |
-| `.agent/scripts/*.mjs` | Copia limpa, **preservando** as constantes de configuracao deste projeto (`TARGETS` no bundle checker, `CHECKS` e `BANNED` nos doc guards) e substituindo os placeholders | Os verificadores sao genericos; so a configuracao e do projeto |
+| `.agent/scripts/**/*.mjs` (inclui `guards/`) | Copia limpa, **preservando** as constantes deste projeto: `TARGETS` em `check-bundle-sizes.mjs`, `BANNED` em `check-doc-versions.mjs` e `CHECKS` em **`guards/versions.mjs`** — mudou de ficheiro quando os guards foram divididos, e um glob `*.mjs` sem `**` nao o apanha. Substituir os placeholders | Os verificadores sao genericos; so a configuracao e do projeto |
 | `.agent/rules/` com conteudo de dominio (`business-logic`, `pages-architecture`) | **Nunca copiar.** Sao 100% deste projeto | Foram gerados no bootstrap a partir das respostas |
 | `.agent/rules/` acumuladas (`anti-patterns`) | **Acrescentar** entradas novas; nunca substituir o ficheiro | O projeto tem anti-padroes proprios, derivados dos seus bugs |
 | `.agent/rules/` de processo (`core-rules`, `process-rules`, `sync-docs`, `ticket-method`) | **Diff obrigatorio.** Se o projeto nao as customizou, copia; se customizou, integrar a mao | Misturam regra generica com decisoes do projeto |
@@ -71,6 +78,10 @@ O que esta **ausente** e candidato a copia. O que existe nos dois vai para a tab
 | Pontos de entrada (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/*.mdc`) | Diff. Preservar a stack e a descricao do projeto; trazer estrutura e tabelas | Cabecalho e do projeto, corpo e do template |
 | `.github/workflows/*` | **So os jobs em falta** (ex: `guard-tests`). Nao substituir o CI do projeto | O CI do projeto pode ter passos proprios |
 | `.claude/settings.json` | Trazer regras de `deny`/`ask` novas; **acrescentar** ao `allow` os scripts novos | O `allow` do projeto reflete o que ele corre |
+| `.claude/agents/*` | Copia se ausentes. **Sao load-bearing**: a Fase 4 exige o subagente `code-reviewer` | Sem eles a Fase 4 nao corre no Claude Code |
+| `src/docs/agent-guide.md` | Diff. Um workflow novo **tem** de aparecer aqui — o Guard 9b reprova se faltar | Duplica a lista de workflows, e o guard verifica-a |
+| `.github/` restante (`CODEOWNERS`, `ISSUE_TEMPLATE/`, `dependabot.yml`, `pull_request_template.md`) | Diff. O PR template deve espelhar o `/review` deste projeto | Governance: metade e do projeto |
+| **Qualquer outro ficheiro versionado** (`README`, `CONTRIBUTING`, `SECURITY`, `LICENSE`, `.editorconfig`, `.nvmrc`, `.gitignore`, `BOOTSTRAP.md`, ...) | **Diff e decidir caso a caso** — nunca overwrite cego | As categorias acima tambem envelhecem; esta linha e a rede |
 
 ## 3. Verificar — e e aqui que o upgrade se prova
 
@@ -95,11 +106,16 @@ ser identico. E, se alguem no projeto trabalha em Windows, confirmar num clone c
 ## 4. Gravar o novo ponto de partida
 
 ```bash
-TPL=<caminho-ou-url-do-template>
+TPL=<caminho-para-um-CLONE-LOCAL-do-template>
+# `--verify ...^{commit}` e obrigatorio: sem ele, `rev-parse main` num template cujo branch
+# principal se chame `master` IMPRIME a palavra "main" e grava uma marca invalida. O upgrade
+# seguinte extrai um SHA vazio, o `git log ""..main` vira `HEAD..main` (vazio) e o workflow
+# reporta "nada a trazer" — falha silenciosa, na direcao perigosa.
+BR=$(git -C "$TPL" symbolic-ref --short HEAD)                # nao assumir `main`
+SHA=$(git -C "$TPL" rev-parse --verify "$BR^{commit}") || { echo "FALHOU: sem commit em $BR"; exit 1; }
 printf 'template: %s\ncommit: %s\ndata: %s\n' \
   "$(git -C "$TPL" remote get-url origin 2>/dev/null || echo "$TPL")" \
-  "$(git -C "$TPL" rev-parse main)" \
-  "$(date +%F)" > .agent/.template-version
+  "$SHA" "$(date +%F)" > .agent/.template-version
 ```
 
 Sem isto, o proximo `/upgrade` cai outra vez no Modo B. **E o unico passo que torna o

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         run: node .agent/scripts/test-backlog.mjs
       - name: Mutation sweep — negative tests
         run: node .agent/scripts/test-mutation-sweep.mjs
-      # A varredura de mutacao recorre cada suite uma vez POR sitio de aviso (~50 sitios),
+      # A varredura de mutacao recorre cada suite uma vez POR sitio de aviso (dezenas de sitios),
       # logo custa minutos, nao segundos. Fica opt-in: correr localmente apos mexer num
       # verificador. Se a quiseres no CI, descomenta e sobe o timeout-minutes deste job.
       # - name: Mutation sweep — cada aviso tem de ficar vermelho

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Branch protection rules (require status checks, block force push) require **GitH
 `.claude/` (slash commands, subagents, `settings.json`) is read **only by Claude Code** — other tools ignore it. But **no logic lives there**: each command is a thin wrapper that says *"read and follow `.agent/workflows/<name>.md`"*. The workflows, rules, and context all live in `.agent/`, which **every agent reads**.
 
 - **Claude Code**: `/plan`, `/review`, etc. are typed slash commands; the permission boundary and subagents apply.
-- **Gemini CLI**: the same 11 commands ship as `.gemini/commands/*.toml`.
+- **Gemini CLI**: the same 12 commands ship as `.gemini/commands/*.toml`.
 - **Any other agent**: ask *"run /plan"* or *"follow `.agent/workflows/plan.md`"* — the identical file.
 
 **What you do lose outside Claude Code**, stated plainly rather than waved away:


### PR DESCRIPTION
## Summary

Ran Fase 4 over **all six** of this session's PRs — it had only run over two — and verified
every finding against the files before acting. Thirteen held up.

- **The worst was a claim of mine, in four places**: the mutation sweep did *not* fail when a checker had no suite. `PARES` is hand-maintained with no discovery, so a new `check-*.mjs` with a warning and no tests was ignored entirely, exit 0. Real discovery now fails with `SEM PAR`.
- **Guard 12d passed in silence** when its citation disappeared — no OK, no WARN, and `guardsRun` still counted it.
- **Two of Guard 13's three constants were inert**: `DOCUMENTAM` had zero executions in 146 tests, `FALSOS` could be replaced with a never-matching regex. The guard reported 1/1 = 100% coverage with two thirds dead.
- **`excludes` was not differential**: a project that adds domain rules picks up a byte-budget WARN and four unrelated tests failed, pointing at the wrong place.
- **`/upgrade` had four defects**, one failing silently in the dangerous direction: `rev-parse main` without `--verify` on a `master`-branch template writes an invalid marker, and the next upgrade reports "nothing to pull".

## Changes

- `mutation-sweep.mjs` — discovery of unregistered checkers (`SEM PAR`); the four false claims corrected in `review.md`, `anti-patterns.md`, `upgrade.md`, `sync-docs.md`.
- `guards/derived-counts.mjs` — 12d gains the missing `cit === 0` branch; header regex tolerates indentation (it was not counting itself: 14 → 16); **Guard 12e** derives the workflow/command count, the fourth hand-maintained number to go stale.
- `guards/placeholders.mjs` — `DOCUMENTAM` becomes load-bearing, dead `FALSOS` alternative removed.
- `check-doc-versions.mjs` — byte budget normalises CRLF: `process-rules.md` changed classification between macOS and Windows purely from line endings.
- `test-harness.mjs` — `excludes` differential; comparison key normalises digits.
- `upgrade.md` — `--verify`, branch detection, `**/*.mjs` for `CHECKS` in `guards/`, and categories for the ~18 files that fell in none, including `.claude/agents/`.
- `anti-patterns.md` — **AP3**: a test that depends on the repo's state instead of building it.

## Test Plan

```
node .agent/scripts/test-guards.mjs           # 150
node .agent/scripts/test-backlog.mjs          #  25
node .agent/scripts/test-bundle-sizes.mjs     #  16
node .agent/scripts/test-mutation-sweep.mjs   #  16
node .agent/scripts/mutation-sweep.mjs        # 95/95, eight targets
```

The six gates pass in **three** states, which is the point of this PR: the bare template, a
fully bootstrapped project (25 placeholders replaced, `package.json`, `BANNED` filled,
`business-logic.md` generated), and a clone with `core.autocrlf=true`. Before this, a test
passed here and failed in every derived project.

Reproductions for the two claims worth checking: create a `check-anything.mjs` with a
`warn()` and no suite, then `mutation-sweep --list` — it must exit 1 with `SEM PAR`. And run
step 4 of `/upgrade` against a template whose branch is `master` — the marker must contain a
SHA, not the word "main".

## Checklist

> **Nota**: repo do template — sem `package.json` nem app, logo `tsc`/`lint`/`build`/`test`/`audit`
> nao se aplicam. Guards, doc sync e secrets corridos.

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] Bundle sizes within targets (if configured — `node .agent/scripts/check-bundle-sizes.mjs`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] E2E tests pass (`npm run test`)
- [ ] Security tests pass (`npm run test:security`)
- [ ] Dependency audit reviewed (`npm run test:audit`) — it is informative in CI, so green does not mean clean
- [ ] Doc guards pass (`node .agent/scripts/check-doc-versions.mjs`) — no WARN
- [ ] If `.agent/scripts/` changed: guard tests pass (`test-guards.mjs`, `test-bundle-sizes.mjs`, `test-backlog.mjs`, `test-mutation-sweep.mjs`)
- [ ] If a `check-*.mjs` changed: `node .agent/scripts/mutation-sweep.mjs` exits 0 (every warning site goes red; no checker without a suite)
- [ ] Backlog counters valid (`node .agent/scripts/check-backlog.mjs`) — 0 divergences
- [ ] CI is green on the branch — never merge on red, and **check that checks exist**: `gh pr checks --watch` exits 0 when none have been reported yet
- [ ] `src/docs/CHANGELOG.md` updated
- [ ] `.agent/context/backlog.md` updated (if applicable)
- [ ] No secrets or credentials in committed files
- [ ] **L ticket, or touches the core domain?** Independent reader ran (Fase 4 — the
      `code-reviewer` subagent, or a separate session given only the diff), each finding
      **verified against the real file**, and CONFIRMED vs PLAUSIBLE stated. It reads code;
      it is not a substitute for the `/review` passes above

