### PR TITLE
docs: Copilot exercitado, e a regra contra contagens escritas à mão

### DIFF
--- a/.agent/rules/anti-patterns.md
+++ b/.agent/rules/anti-patterns.md
@@ -41,6 +41,14 @@
   (A versao anterior desta entrada trazia o numero de sitios escrito a mao. Envelheceu na
   primeira alteracao ao verificador, e a receita ao lado nunca chegava a esse numero —
   por isso o numero passou a ser derivado por um script.)
+- **A forma mais teimosa: numeros em prosa e em mensagens de commit.** Numa unica sessao o
+  mesmo numero foi escrito errado **quatro vezes** — "9 das 10 suites" (envelheceu ao dividir
+  uma suite), "todas menos uma" (eram 2 de 11), "as 28 formas" (a tabela tinha 47), e
+  "34 -> 48 casos" numa mensagem de commit (eram 47). Uma mensagem de commit e **imutavel**:
+  um numero errado la fica errado para sempre. Regra: **nao escrever contagens que nao se
+  derivaram no momento**. Ou se corre o comando e se cola o resultado, ou se escreve o comando
+  em vez do numero. O que nao envelhece sao os **eventos** ("a leitura encontrou 22 defeitos"),
+  porque descrevem o passado; contagens descrevem o presente, e o presente muda.
 
 ## AP2 — Zero resultados lido como zero problemas
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Branch protection rules (require status checks, block force push) require **GitH
 |-------|--------------------|----------------|--------------|
 | Claude Code | `CLAUDE.md` (+ `.claude/`) | native (all of them) | Used throughout this template's own development |
 | Google Gemini CLI | `GEMINI.md` | native (`.gemini/commands/`) | Entry file and wrappers checked by Guards 2, 6, 7, 10 |
-| GitHub Copilot | `.github/copilot-instructions.md` | no | File shipped and points to `AGENTS.md`; **not exercised in a real Copilot session** |
+| GitHub Copilot | `.github/copilot-instructions.md` | no | **Exercised in a real Copilot session** (maintainer, 2026-09-10): Copilot loads the file and answers from the project's rules |
 | Cursor | `.cursor/rules/*.mdc` | no | Same — shipped, pointing to `AGENTS.md`; **not exercised in a real Cursor session** |
 | ChatGPT / Codex | `AGENTS.md` | no | Same — `AGENTS.md` is its documented convention; **not exercised** |
 | Windsurf, Zed, others | `AGENTS.md` (if supported) | no | Unverified — check your tool's docs for which file it loads |
@@ -333,6 +333,15 @@ Branch protection rules (require status checks, block force push) require **GitH
 > while listing `CLAUDE.md` as their entry file — which neither tool loads, and no such test
 > had been run. The columns above say what was actually done. If you exercise one of the
 > unverified rows, a PR correcting it is welcome.
+>
+> **How to exercise a row properly.** Since the **Fronteiras** block is now inlined in
+> `.github/copilot-instructions.md` and `.cursor/rules/project.mdc` (so those tools get the
+> non-negotiable rules even if they don't follow references), a tool answering *"what's the
+> branch rule?"* proves it **reads its entry file** — but not that it **follows the pointer**
+> to `AGENTS.md` and `.agent/`. To test the pointer, ask something that lives only deeper, for
+> example *"which state-management library must I use for data fetching, and why not
+> `useEffect`?"* (that's in `.agent/rules/core-rules.md` and nowhere else). If the answer is
+> vague, the tool needs content inlined rather than referenced.
 
 > **Why multiple entry files?** Claude Code parses `@file`, Gemini needs `@[file]` brackets, and `AGENTS.md` is the tool-neutral cross-tool entry. All share the same source of truth in `.agent/` — only syntax/entry differs.
 


### PR DESCRIPTION
## Duas coisas, ambas vindas de validação

**1. O Copilot passou a estar exercitado.** O mantenedor correu uma sessão real: o Copilot carrega o `.github/copilot-instructions.md` e responde a partir das regras do projeto. A linha da tabela de compatibilidade deixa de dizer *"not exercised"*.

Fica a subtileza que isto criou: depois de as **Fronteiras** estarem inline nesse ficheiro (PR #26), um tool que responda *"qual é a regra de branch?"* prova que **lê o seu ficheiro de entrada** — não que **segue o ponteiro** para o `AGENTS.md`. O README passa a dar a pergunta que testa o ponteiro (a regra de data fetching, que existe só no `core-rules.md`). Sem isto, a próxima pessoa a testar o Cursor tirava a conclusão errada de uma resposta certa.

**2. A quarta geração do mesmo erro meu.** Auditar as mensagens de commit desta sessão contra o que os diffs fizeram — um ângulo novo — encontrou mais duas afirmações erradas em `aa24f2e`: escrevi `BYPASSES 34 → 48` e `legítimos 20 → 30`; os valores reais eram **47** e **29**. Na mesma mensagem onde corrigia números errados.

Com isso são quatro vezes numa sessão. E uma mensagem de commit é **imutável**: fica errada para sempre. O `AP1` ganha a regra: **não escrever contagens que não se derivaram no momento** — corre-se o comando e cola-se, ou escreve-se o comando em vez do número. O que não envelhece são os **eventos**, porque descrevem o passado.

## Verificação

```
418 asserções (soma derivada, não escrita à mão) · 0 falhas
check-doc-versions 0 · check-backlog 0 · check-test-surface 0
contexto carregado: 40531 bytes (NOTE a 56000)
```

E a afirmação de `826276e` (411 asserções) confirmou-se exacta, medida a correr as suites num worktree desse commit.