### PR TITLE
chore(backlog): dar razão aos pendentes, e recusar uma segunda escala de prioridade

### DIFF
--- a/.agent/context/backlog.md
+++ b/.agent/context/backlog.md
@@ -41,11 +41,19 @@
 
 ## Pendentes sem Sprint
 
-> Items aprovados no backlog mas ainda nao atribuidos a um sprint.
+> Items aprovados no backlog mas ainda nao atribuidos a um sprint. A coluna **Nota** diz
+> **porque** esta parqueado e o que o desbloqueia (ex: "precisa de dados reais", "depende do
+> F12", "valor por confirmar") — sem isso, um item volta a ser discutido de zero cada vez que
+> se planeia um sprint.
+>
+> **Prioridade nao se escreve aqui nem no sprint.** No sprint, a `Ordem` **e** a prioridade;
+> uma coluna de urgencia ao lado dela seriam dois campos a ter de concordar a mao, sem nada a
+> verifica-los — e ao primeiro reordenar o documento passa a mentir (ver `AP1`). Nesta tabela
+> nao ha ordem porque a decisao ainda nao foi tomada: o que falta e a **razao**, nao um rotulo.
 
-| ID | Descricao | Esforco |
-|----|-----------|---------|
-| | | |
+| ID | Descricao | Esforco | Nota |
+|----|-----------|---------|------|
+| | | | |
 
 ---
 


### PR DESCRIPTION
## De onde veio

Um projeto derivado acrescentou uma coluna **`Urgencia`** à tabela de sprint. A pergunta era se o template devia ter o mesmo. A análise diz **não** — e aponta para um buraco real ao lado.

## Porque não no sprint

A tabela é `Ordem | ID | Descricao | Esforco | Depende de`, e a **`Ordem` é a decisão que a urgência informa**. As duas lado a lado são dois campos que têm de concordar à mão, sem nada a verificá-los: ao primeiro reordenar sem mexer no rótulo, o documento mente e ninguém dá por isso. É o `AP1`.

Havia ainda uma **terceira** escala para o mesmo conceito, porque a tabela de Bugs já tem `Severidade`.

## Onde o buraco é real

**"Pendentes sem Sprint"** era `ID | Descricao | Esforco` — é o sítio onde se decide o que entra a seguir, e o template não dava nada com que decidir: nem ordem, nem razão. Um item voltava a ser discutido de zero a cada planeamento.

A coluna que fecha isso não é urgência: é **`Nota`** — porque está parqueado e o que o desbloqueia (*"precisa de dados reais"*, *"depende do F12"*). Um bloqueio diz o que fazer; um rótulo de prioridade não. E o projeto derivado chegou lá por si: é o que a coluna `Nota` dele contém.

O blockquote da secção passa a dizer as duas coisas — o que a `Nota` leva, e que prioridade não se duplica.

## Segurança da alteração, verificada antes de mexer

O `check-backlog.mjs` parseia **só** as quatro tabelas por tipo e o Histórico do archive, e depende da posição de `cells[0]`/`cells[1]` — a tabela dos pendentes não é lida, logo a coluna nova não toca no gate. Propagação completa: o archive não tem tabela paralela e nenhum outro ficheiro documenta estas colunas.

```
418 asserções, 0 falhas
check-doc-versions 0 · check-backlog 0 · check-test-surface 0
contexto carregado: 41163 bytes (NOTE a 56000)
```