### PR TITLE
chore: ignorar os relatorios externos de revisao

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ coverage/
 # Estado local dos hooks — memoria desta maquina, nao do repo
 .claude/state/
 
+# Relatorios externos de revisao (TEMPLATE-FIXES*.md e afins): sao entregues a sessao, nao
+# fazem parte do template, e nenhum chegou a ser commitado. Sem esta linha ficavam so a
+# depender de quem faz `git add` os escolher um a um — e um `git add -A` distraido leva-os.
+TEMPLATE-FIXES*.md
+
 # OS / logs
 .DS_Store
 *.log


### PR DESCRIPTION
## O que muda

Uma linha no `.gitignore`: `TEMPLATE-FIXES*.md`.

## Porque

O `TEMPLATE-FIXES.md` e o `TEMPLATE-FIXES-2.md` sao relatorios de revisao entregues a sessao de fora. Nenhum chegou a ser commitado — mas isso dependia inteiramente de quem fazia `git add` os escolher ficheiro a ficheiro, que foi o que aconteceu no #31. Um `git add -A` distraido de um proximo agente levava-os para dentro do template, e sao o registo de uma revisao concreta, nao parte dele.

O ficheiro continua no disco; deixa e de aparecer como untracked.

## Checklist

- [x] `node .agent/scripts/check-doc-versions.mjs` — exit 0
- [x] O ficheiro sai de `git status --porcelain` e continua em disco (verificado)
- [x] Sem impacto em rules, scripts ou suites