### PR TITLE
feat(scripts): simular um projeto derivado e correr la as verificacoes

### DIFF
--- a/.agent/BOOTSTRAP.md
+++ b/.agent/BOOTSTRAP.md
@@ -224,7 +224,7 @@ Apos obter as respostas, a AI deve processar TODOS os ficheiros abaixo:
 
 ### 2.1 Substituicao de Placeholders (em TODOS os ficheiros do template)
 
-Percorrer todos os `.md`, `.mdc` (regras do Cursor), `.mjs`, `LICENSE` e `.github/CODEOWNERS` e substituir:
+Percorrer todos os `.md`, `.mdc` (regras do Cursor), `.mjs`, `LICENSE`, `.github/CODEOWNERS` e **os ficheiros de `.githooks/`** (nao tem extensao — o git exige o nome exacto do evento) e substituir:
 
 | Placeholder | Fonte |
 |-------------|-------|

--- a/.agent/rules/scripts-guide.md
+++ b/.agent/rules/scripts-guide.md
@@ -43,6 +43,8 @@
 > canonica do `AP2`.
 
 
+- **Simulador de projeto derivado** (`.agent/scripts/simulate-derived.mjs` + `test-simulate-derived.mjs`): monta um projeto derivado (copia, substitui placeholders, gera as rules do bootstrap, aplica o passo 2.8) e corre la os verificadores. E a unica coisa que testa a promessa do template — todas as outras suites correm sobre o template **nu**. **Nao** se chama `check-*` de proposito: orquestra verificadores que ja tem par, e um alvo sem sitios de aviso proprios reprova na descoberta do sweep com `SINAL ERRADO`. Corre no CI em `pull_request` (~50s). O limite esta no cabecalho: simula o **estado** "bootstrap concluido", nao executa a checklist passo a passo.
+
 ## A regra que os liga
 
 Cada verificador **e cada hook** tem de ter **a sua suite de testes negativos** e **a sua

--- a/.agent/rules/sync-docs.md
+++ b/.agent/rules/sync-docs.md
@@ -56,6 +56,10 @@ Nao basta atualizar apenas os ficheiros de contexto (`.agent/context/`) — e ob
 23. [ ] `CONTRIBUTING.md` — workflow, commit format e PR process atualizados
 24. [ ] `SECURITY.md` — politica de disclosure atualizada
 25. [ ] `.nvmrc` — fonte unica da versao Node (CI le via `node-version-file`)
+25a. [ ] **Ficheiro novo com um `{{PLACEHOLDER}}`?** O bootstrap tem de o varrer: confirmar que
+    o tipo dele esta na Fase 2.1 do `BOOTSTRAP.md`, nos alvos do Guard 13 e no
+    `simulate-derived.mjs`. Um `.githooks/commit-msg` sem extensao escapou as tres e o
+    placeholder sobrevivia ao bootstrap — apanhado pela simulacao de projeto derivado.
 25b. [ ] `.githooks/` — hook novo ou alterado? Entao (a) tem a sua suite `test-*.mjs`, (b) esta
     em `PARES` no `mutation-sweep.mjs` com o seu `sinal`, (c) a suite corre no job `guard-tests`
     do `ci.yml`, e (d) o passo `git config core.hooksPath .githooks` continua documentado no

--- a/.agent/scripts/guards/placeholders.mjs
+++ b/.agent/scripts/guards/placeholders.mjs
@@ -72,6 +72,12 @@ export function guardPlaceholders({ read, warn, ok, skip, listDir }) {
     ...(listDir(".agent/scripts/guards", ".mjs") || []).map((f) => `.agent/scripts/guards/${f}.mjs`),
     ...(listDir(".claude/commands", ".md") || []).map((f) => `.claude/commands/${f}.md`),
     ...(listDir(".gemini/commands", ".toml") || []).map((f) => `.gemini/commands/${f}.toml`),
+    // Os hooks do git. Nao tem extensao — o git exige o nome exacto do evento — e por isso
+    // escaparam a Fase 2.1 do bootstrap **e** a esta lista quando foram criados: um
+    // `{{PROJECT_NAME}}` ficava la para sempre num projeto derivado. Apanhado pela varredura
+    // do `simulate-derived.mjs`, no dia em que ela passou a olhar para alem das extensoes que
+    // ela propria substitui.
+    ...(listDir(".githooks", "") || []).map((f) => `.githooks/${f}`),
   ];
 
   let ficheirosComSobras = 0;

--- a/.agent/scripts/simulate-derived.mjs
+++ b/.agent/scripts/simulate-derived.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * Simula um PROJETO DERIVADO e corre la as verificacoes — {{PROJECT_NAME}}
+ *
+ * PORQUE EXISTE: este repo e um template, e a promessa dele e "funciona no teu projeto
+ * derivado". Todas as outras suites correm sobre o template **nu** — placeholders por
+ * substituir, rules do bootstrap por gerar. Nenhuma testava a promessa.
+ *
+ * Nao e teorico. A primeira corrida desta simulacao encontrou a checklist do `BOOTSTRAP.md` a
+ * mandar deixar o `anti-patterns.md` "sem entradas" — estado em que os ficheiros do template
+ * deixam dezenas de citacoes penduradas e o consumidor leva exit 1 **no dia 1**. Tres leituras
+ * independentes nao viram; uma corrida viu em minutos. E a licao do `AP2` e do `ticket-method`
+ * ("correr os comandos que a documentacao manda correr") com instrumento.
+ *
+ * NAO E UM `check-*.mjs`, e o nome e deliberado: a descoberta do `mutation-sweep.mjs` varre
+ * `check-*.mjs` e `guards/*.mjs` e exige par em `PARES`; um alvo sem sitios de aviso proprios
+ * reprova la com `SINAL ERRADO`. Este ficheiro **orquestra** verificadores que ja tem par e
+ * suite — o veredicto dele e o exit code deles, nao uma decisao sua. A sua propria logica (o
+ * que copia, o que substitui, o que gera, e recusar-se a dar OK sem ter medido) tem suite
+ * propria em `test-simulate-derived.mjs`.
+ *
+ * O QUE FAZ, a espelhar a Fase 2 do `BOOTSTRAP.md`:
+ *   1. copia o repo sem `.git` nem o que nao pertence a um clone novo;
+ *   2. substitui os `{{PLACEHOLDER}}`;
+ *   3. cria as rules que o bootstrap GERA (sao o discriminador de "bootstrap concluido");
+ *   4. corre os verificadores e as suites, e reprova se algum sair != 0.
+ *
+ * A lista de extensoes do passo 2 nao precisa de estar perfeita para o resultado ser de
+ * confianca: se faltar alguma, sobram placeholders e o **Guard 13 dispara** no passo 4. A
+ * simulacao denuncia-se a si mesma em vez de passar a medir menos.
+ *
+ * O LIMITE, dito por inteiro porque e o mesmo erro que o `AP7` documenta: isto simula o
+ * **estado** "bootstrap concluido", e nao **executa a checklist** do `BOOTSTRAP.md` passo a
+ * passo. Aplica os que sao mecanicos (2.1 substituir, 2.2 gerar, e o unico passo destrutivo do
+ * 2.8 — apagar o exemplo comentado do `anti-patterns.md`). Uma instrucao errada noutro passo —
+ * que foi exactamente o defeito que motivou este script — so e apanhada se alguem a seguir a
+ * mao. Isto reduz a janela; nao a fecha. Quem acrescentar um passo mecanico a Fase 2 devia
+ * acrescenta-lo aqui.
+ *
+ * Uso:
+ *   node .agent/scripts/simulate-derived.mjs             # corre tudo
+ *   node .agent/scripts/simulate-derived.mjs --keep      # nao apaga a copia (para inspeccionar)
+ *   node .agent/scripts/simulate-derived.mjs --only=check-doc-versions,test-guards
+ */
+
+import { cpSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "fs";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, resolve, join } from "path";
+import { tmpdir } from "os";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Nao pertencem a um clone novo. `TEMPLATE-FIXES*` sao relatorios de revisao entregues de
+ *  fora (ver `.gitignore`); `node_modules` e `.git` sao obvios. */
+const NAO_COPIAR = [".git", "node_modules"];
+const NAO_COPIAR_PREFIXO = ["TEMPLATE-FIXES"];
+
+/** Tipos que a Fase 2.1 do BOOTSTRAP manda varrer. Se esta lista ficar curta, sobram
+ *  placeholders e o Guard 13 reprova no passo 4 — por desenho. */
+const SUBSTITUIVEIS = /\.(md|mdc|mjs|json|yml|yaml|toml)$/;
+const SUBSTITUIVEIS_SEM_EXT = new Set(["LICENSE", "CODEOWNERS"]);
+/** Os hooks do git nao tem extensao (o git exige o nome exacto do evento), logo precisam de
+ *  regra propria — e foi por nao a terem que um `{{PROJECT_NAME}}` la sobrevivia ao bootstrap. */
+const substituivel = (rel, nome) =>
+  rel.startsWith(".githooks/") || SUBSTITUIVEIS.test(nome) || SUBSTITUIVEIS_SEM_EXT.has(nome);
+
+/** `{{args}}` e um placeholder dos command templates do Gemini, nao do bootstrap. */
+const PLACEHOLDER = /\{\{(?!args\})[A-Z_]+\}\}/g;
+
+/** O que a Fase 2.2 do BOOTSTRAP manda GERAR. Derivado do proprio BOOTSTRAP.md para nao
+ *  envelhecer: se alguem acrescentar um ficheiro gerado a tabela 2.2, esta lista segue. */
+function rulesGeradas() {
+  const b = leOuNull(join(ROOT, ".agent/BOOTSTRAP.md"));
+  if (b === null) return [];
+  const seccao = b.split(/^### 2\.2 /m)[1]?.split(/^### 2\.3 /m)[0] ?? "";
+  return [...new Set([...seccao.matchAll(/`(\.agent\/rules\/[a-z-]+\.md)`/g)].map((m) => m[1]))];
+}
+
+/** Os comandos que um projeto derivado corre — os mesmos do `guard-tests` do `ci.yml`. */
+const COMANDOS = [
+  ".agent/scripts/check-doc-versions.mjs",
+  ".agent/scripts/check-backlog.mjs",
+  ".agent/scripts/test-guards.mjs",
+  ".agent/scripts/test-test-surface.mjs",
+  ".agent/scripts/test-bundle-sizes.mjs",
+  ".agent/scripts/test-backlog.mjs",
+  ".agent/scripts/test-mutation-sweep.mjs",
+  ".agent/scripts/test-commit-msg.mjs",
+  ".claude/hooks/tests/test-hooks.mjs",
+];
+
+const leOuNull = (p) => {
+  try {
+    return readFileSync(p, "utf8");
+  } catch {
+    return null;
+  }
+};
+
+let problemas = 0;
+const warn = (m) => {
+  console.log(`  WARN  ${m}`);
+  problemas++;
+};
+const ok = (m) => console.log(`  OK    ${m}`);
+/** Nao consegui medir: reprova na hora. Existe como funcao e nao como `console.log` +
+ *  `process.exit` soltos — ver a nota equivalente no `check-test-surface.mjs`. */
+const fatal = (m) => {
+  console.log(`  WARN  ${m}`);
+  console.log("");
+  process.exit(1);
+};
+
+const args = process.argv.slice(2);
+const manter = args.includes("--keep");
+const only = args.find((a) => a.startsWith("--only="))?.slice("--only=".length);
+const selecionados = only
+  ? COMANDOS.filter((c) => only.split(",").some((o) => c.includes(o.trim())))
+  : COMANDOS;
+
+if (selecionados.length === 0) {
+  fatal(`--only=${only} nao seleccionou nenhum comando — nada a correr nao e sucesso`);
+}
+
+console.log("\n=== Simulacao de projeto derivado ===\n");
+
+// --- 1. copiar -----------------------------------------------------------------
+const dir = mkdtempSync(join(tmpdir(), "derivado-"));
+let copiados = 0;
+for (const e of readdirSync(ROOT, { withFileTypes: true })) {
+  if (NAO_COPIAR.includes(e.name)) continue;
+  if (NAO_COPIAR_PREFIXO.some((p) => e.name.startsWith(p))) continue;
+  cpSync(join(ROOT, e.name), join(dir, e.name), { recursive: true });
+  copiados++;
+}
+if (copiados === 0) fatal("nao copiei nada do repo — a simulacao nao mediria nada");
+
+// --- 2. substituir placeholders -------------------------------------------------
+let tocados = 0;
+const anda = (rel) => {
+  for (const e of readdirSync(join(dir, rel), { withFileTypes: true })) {
+    const sub = rel ? `${rel}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      anda(sub);
+      continue;
+    }
+    if (!substituivel(sub, e.name)) continue;
+    const p = join(dir, sub);
+    const c = readFileSync(p, "utf8");
+    const novo = c.replace(PLACEHOLDER, "ProjetoDerivado");
+    if (novo !== c) {
+      writeFileSync(p, novo);
+      tocados++;
+    }
+  }
+};
+anda("");
+ok(`${copiados} entrada(s) copiada(s), ${tocados} ficheiro(s) com placeholders substituidos`);
+
+// O invariante que importa nao e "substitui alguma coisa" — e "nao sobrou nada". A primeira
+// versao reprovava com `tocados === 0`, e isso era **inalcancavel**: este proprio ficheiro tem
+// um placeholder no cabecalho, logo a contagem nunca e zero enquanto ele existir. Pior, o unico
+// sitio onde chegaria a ser zero e um projeto ja bootstrapado — onde zero e o estado CORRECTO —
+// e o script reprovava em todos os consumidores. E o `AP7` e o `AP3` no mesmo sitio.
+//
+// Isto, sim, dispara quando a lista de extensoes fica curta: sobra um `{{...}}` na copia e a
+// simulacao deixa de ser fiel. O `BOOTSTRAP.md` e o `README.md` ficam de fora porque
+// **documentam** os placeholders — e a mesma excecao que o Guard 13 faz.
+const DOCUMENTAM = new Set([".agent/BOOTSTRAP.md", "README.md"]);
+/** Nao sao texto: um `{{...}}` la dentro nao instrui agente nenhum, e ler binario como utf8 so
+ *  produz ruido. */
+const BINARIOS = /\.(png|jpe?g|gif|webp|svg|ico|pdf|zip|gz|woff2?|ttf|otf|mp[34]|mov)$/i;
+const sobras = [];
+const procura = (rel) => {
+  for (const e of readdirSync(join(dir, rel), { withFileTypes: true })) {
+    const sub = rel ? `${rel}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      procura(sub);
+      continue;
+    }
+    if (DOCUMENTAM.has(sub)) continue;
+    // **Sem** o filtro `SUBSTITUIVEIS`, e e o ponto todo: com ele, um tipo de ficheiro que a
+    // substituicao nao cobre era tambem ignorado por esta varredura — cega precisamente ao
+    // caso que diz apanhar. Apanhado pelo teste, nao pela leitura.
+    if (BINARIOS.test(e.name)) continue;
+    let c;
+    try {
+      c = readFileSync(join(dir, sub), "utf8");
+    } catch {
+      continue; // ilegivel como texto: nao e onde um placeholder engana alguem
+    }
+    const m = c.match(PLACEHOLDER);
+    if (m) sobras.push(`${sub} (${[...new Set(m)].join(", ")})`);
+  }
+};
+procura("");
+if (sobras.length) {
+  fatal(
+    `sobraram placeholders por substituir em ${sobras.length} ficheiro(s) — a simulacao nao e ` +
+      `fiel a um projeto bootstrapado. Primeiro: ${sobras[0]}`
+  );
+}
+
+// --- 3. gerar as rules do bootstrap ----------------------------------------------
+const geradas = rulesGeradas();
+if (geradas.length === 0) {
+  fatal("nao derivei nenhuma rule gerada da seccao 2.2 do BOOTSTRAP.md — o formato mudou?");
+}
+for (const rel of geradas) {
+  const p = join(dir, rel);
+  mkdirSync(dirname(p), { recursive: true });
+  const nome = rel.split("/").pop().replace(".md", "");
+  writeFileSync(p, `# ${nome} (ProjetoDerivado)\n\nConteudo gerado no bootstrap deste projeto.\n`);
+}
+ok(`${geradas.length} rule(s) do bootstrap geradas: ${geradas.map((g) => g.split("/").pop()).join(", ")}`);
+
+// --- 3b. o unico passo DESTRUTIVO da Fase 2 que e mecanico ------------------------
+// A 2.8 manda apagar o exemplo comentado do `anti-patterns.md` — e **so** esse. Foi aqui que
+// a instrucao esteve errada (mandava deixar o ficheiro sem entradas, o que deixa dezenas de
+// citacoes penduradas); simular o passo certo e o que impede a versao errada de voltar sem
+// ninguem notar.
+{
+  const rel = ".agent/rules/anti-patterns.md";
+  const p = join(dir, rel);
+  const c = leOuNull(p);
+  if (c !== null) {
+    const semExemplo = c.replace(/<!--[\s\S]*?-->\n*/g, "");
+    if (semExemplo !== c) {
+      writeFileSync(p, semExemplo);
+      ok("exemplo comentado do anti-patterns.md removido (passo 2.8)");
+    } else {
+      ok("anti-patterns.md sem exemplo comentado a remover");
+    }
+  }
+}
+
+// --- 4. correr -------------------------------------------------------------------
+console.log("");
+let corridos = 0;
+for (const c of selecionados) {
+  if (!existsSync(join(dir, c))) {
+    warn(`${c}: ausente na copia — nao consegui correr`);
+    continue;
+  }
+  let code = 0;
+  let out = "";
+  try {
+    out = execFileSync(process.execPath, [join(dir, c)], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    code = err.status ?? 1;
+    out = (err.stdout ?? "") + (err.stderr ?? "");
+  }
+  corridos++;
+  const resumo = (out.match(/^\s*\d+ passaram, \d+ falharam\.$/m) ?? [""])[0].trim();
+  if (code === 0) {
+    ok(`${c}${resumo ? ` — ${resumo}` : ""}`);
+  } else {
+    warn(`${c}: exit ${code}${resumo ? ` — ${resumo}` : ""}`);
+    for (const l of out.split("\n").filter((l) => /^\s*(WARN|FAIL)/.test(l)).slice(0, 8)) {
+      console.log(`          ${l.trim()}`);
+    }
+  }
+}
+
+if (!manter) rmSync(dir, { recursive: true, force: true });
+else console.log(`\n  copia mantida em ${dir}`);
+
+// Zero comandos corridos com uma seleccao valida seria dar OK sem ter medido nada.
+if (corridos === 0) fatal("nenhum comando chegou a correr — a simulacao nao mediu nada");
+
+console.log("");
+if (problemas > 0) {
+  console.log(`WARNING: ${problemas} verificacao(oes) falham num projeto DERIVADO.`);
+  console.log("         Passam no template nu — logo o defeito e do bootstrap ou de uma");
+  console.log("         assercao que depende do estado deste repo (ver AP3).\n");
+  process.exit(1);
+}
+console.log(`  ${corridos} verificacao(oes) verdes num projeto derivado.\n`);

--- a/.agent/scripts/test-simulate-derived.mjs
+++ b/.agent/scripts/test-simulate-derived.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Testes do simulador de projeto derivado — {{PROJECT_NAME}}
+ *
+ * Testes NEGATIVOS da logica **propria** do `simulate-derived.mjs`: o que copia, o que
+ * substitui, o que gera, e — sobretudo — recusar-se a dar OK quando nao mediu nada.
+ *
+ * O veredicto sobre os verificadores nao e testado aqui: e o exit code deles, e cada um ja tem
+ * a sua suite. O que se testa e o arnes.
+ *
+ * A fixture e um repo MINIMO montado do zero, com stubs no lugar dos verificadores — logo cada
+ * caso corre em milissegundos em vez dos ~50s da simulacao a serio. O simulador ancora a raiz
+ * a sua propria localizacao, logo copia-lo para a fixture faz com que ele simule a fixture: e
+ * o mesmo truque do `test-harness.mjs`.
+ *
+ *   node .agent/scripts/test-simulate-derived.mjs
+ *
+ * Sai `!= 0` se algum teste falhar. Corre no job `guard-tests` do `ci.yml`.
+ */
+
+import { execFileSync } from "child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { fileURLToPath } from "url";
+import { dirname, resolve, join } from "path";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SIMULADOR = join(ROOT, ".agent/scripts/simulate-derived.mjs");
+
+/** Os caminhos que o simulador tenta correr. Derivados do PROPRIO simulador, e nao escritos a
+ *  mao: uma lista fixa aqui envelhecia no primeiro comando que o simulador acrescentasse, e os
+ *  testes passavam a medir stubs que ele ja nao chama. */
+const COMANDOS = [...
+  execFileSync("node", ["-e", `
+    const s = require("fs").readFileSync(${JSON.stringify(SIMULADOR)}, "utf8");
+    const bloco = s.split("const COMANDOS = [")[1].split("];")[0];
+    process.stdout.write([...bloco.matchAll(/"([^"]+)"/g)].map((m) => m[1]).join("\\n"));
+  `], { encoding: "utf8" }).split("\n").filter(Boolean)];
+
+if (COMANDOS.length === 0) {
+  console.error("nao consegui derivar a lista de comandos do simulador — o formato mudou?");
+  process.exit(1);
+}
+
+let passed = 0;
+const falhas = [];
+
+/** Repo minimo, limpo por construcao: um placeholder para substituir, uma seccao 2.2 no
+ *  BOOTSTRAP para derivar, e um stub por cada comando que o simulador chama. */
+function fixture({ stubFalha = null, sobraPlaceholder = false, bootstrapQuebrado = false, semStubs = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "sim-test-"));
+  const w = (rel, body) => {
+    const p = join(dir, rel);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, body);
+  };
+
+  w(".agent/BOOTSTRAP.md", bootstrapQuebrado
+    ? "# Bootstrap\n\nSem a seccao que o simulador procura.\n"
+    : "# Bootstrap\n\n### 2.2 Ficheiros a GERAR do zero\n\n| Ficheiro |\n|---|\n" +
+      "| `.agent/rules/business-logic.md` |\n\n### 2.3 Outra coisa\n\nTexto.\n");
+
+  // O placeholder e construido, nao escrito: o bootstrap substitui placeholders tambem em
+  // `.mjs`, logo um literal aqui seria reescrito num projeto derivado e a fixture deixava de
+  // ter o que o teste precisa.
+  const ph = "{" + "{" + "PROJECT_NAME" + "}" + "}";
+  // O `README.md` esta na lista dos que DOCUMENTAM placeholders, logo nao serve de cobaia:
+  // uma rule serve, e e onde um placeholder esquecido de facto engana o agente.
+  w(".agent/rules/core-rules.md", `# ${ph}\n\nTexto.\n`);
+  w("README.md", "# Readme\n");
+  // `sobraPlaceholder` simula a lacuna real: um placeholder num tipo de ficheiro que a
+  // substituicao **nao** cobre. O `.txt` nao esta em nenhuma das listas — e e essa a forma do
+  // defeito que isto apanhou de verdade: o `.githooks/commit-msg`, que nao tem extensao.
+  if (sobraPlaceholder) w("NOTAS.txt", `Projeto: ${ph}\n`);
+
+  w(".agent/rules/anti-patterns.md",
+    "# Anti-Padroes\n\n<!-- Exemplo a remover no bootstrap.\n\n## AP1 — exemplo\n\n-->\n\n## AP1 — real\n");
+
+  for (const [i, c] of semStubs ? [] : COMANDOS.entries()) {
+    const falha = stubFalha !== null && c.includes(stubFalha);
+    w(c, `#!/usr/bin/env node\nconsole.log("  ${i} passaram, ${falha ? 1 : 0} falharam.");\n` +
+         `process.exit(${falha ? 1 : 0});\n`);
+  }
+
+  mkdirSync(join(dir, ".agent/scripts"), { recursive: true });
+  copyFileSync(SIMULADOR, join(dir, ".agent/scripts/simulate-derived.mjs"));
+  return dir;
+}
+
+function test(nome, opcoes, expect) {
+  const dir = fixture(opcoes);
+  try {
+    let code = 0;
+    let out = "";
+    try {
+      out = execFileSync("node", [join(dir, ".agent/scripts/simulate-derived.mjs"), ...(expect.args ?? [])], {
+        cwd: dir,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (e) {
+      code = e.status ?? -1;
+      out = (e.stdout ?? "") + (e.stderr ?? "");
+    }
+    const problemas = [];
+    if (code !== expect.code) problemas.push(`exit ${code}, esperado ${expect.code}`);
+    // Quando se espera reprovacao, afirma-se contra as linhas WARN e nada mais: um `includes`
+    // sobre o output inteiro seria satisfeito por uma linha OK com o mesmo texto (`AP1`).
+    const alvo = expect.code === 0
+      ? out
+      : out.split("\n").filter((l) => l.trimStart().startsWith("WARN")).join("\n");
+    for (const s of expect.includes ?? []) {
+      if (!alvo.includes(s)) problemas.push(`${expect.code === 0 ? "output" : "linhas WARN"} devia conter "${s}"`);
+    }
+    for (const s of expect.excludes ?? []) {
+      if (out.includes(s)) problemas.push(`output NAO devia conter "${s}"`);
+    }
+    if (problemas.length) {
+      falhas.push({ nome, problemas, out });
+      console.log(`  FAIL  ${nome}`);
+      for (const p of problemas) console.log(`          ${p}`);
+    } else {
+      passed++;
+      console.log(`  PASS  ${nome}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("\n=== Testes do simulador de projeto derivado ===\n");
+
+// --- O caminho feliz, e o que ele tem de declarar -------------------------------
+test("fixture sa: corre tudo e declara quantas verificacoes passaram", {}, {
+  code: 0,
+  includes: [`${COMANDOS.length} verificacao(oes) verdes num projeto derivado`],
+  excludes: ["  WARN  "],
+});
+
+// --- Um verificador que falha no DERIVADO tem de reprovar a simulacao -----------
+// E a razao de existir do script: um defeito que so aparece depois do bootstrap.
+test("um verificador a falhar reprova a simulacao, e e nomeado", { stubFalha: COMANDOS[0] }, {
+  code: 1,
+  includes: [COMANDOS[0], "exit 1"],
+});
+
+// --- "Nao consegui medir" tem de REPROVAR, nao dar OK (AP2) ---------------------
+// A primeira versao deste teste afirmava "zero placeholders substituidos reprova". Era
+// inalcancavel: o proprio simulador tem um placeholder no cabecalho, logo a contagem nunca e
+// zero — e o ramo do script que ele testava so dispararia num projeto ja bootstrapado, onde
+// zero e o estado CORRECTO. O que se mede agora e o invariante que interessa: nao sobrar
+// nenhum placeholder na copia.
+test("um placeholder que sobra na copia reprova", { sobraPlaceholder: true }, {
+  code: 1,
+  includes: ["sobraram placeholders", "NOTAS.txt"],
+});
+
+// O controlo do controlo: sem a sobra, nao pode haver falso positivo.
+test("sem sobras, a varredura de placeholders nao acusa nada", {}, {
+  code: 0,
+  excludes: ["sobraram placeholders"],
+});
+
+// O ramo mais facil de esquecer: todos os comandos ausentes. Sem o `fatal`, o script chegava
+// ao fim a contar avisos em vez de dizer que nao mediu nada — e a diferenca importa, porque
+// "falharam" e "nao correram" pedem accoes diferentes a quem le. E o `AP2`.
+test("nenhum comando a correr reprova a dizer que nao mediu", { semStubs: true }, {
+  code: 1,
+  includes: ["nao mediu nada"],
+});
+
+test("BOOTSTRAP sem a seccao 2.2 reprova, em vez de gerar nada em silencio", { bootstrapQuebrado: true }, {
+  code: 1,
+  includes: ["nenhuma rule gerada"],
+});
+
+test("`--only` que nao selecciona nada reprova", {}, {
+  code: 1,
+  args: ["--only=nao-existe-nenhum"],
+  includes: ["nao seleccionou nenhum comando"],
+});
+
+// --- O passo 2.8: o unico destrutivo que o simulador aplica --------------------
+test("o exemplo comentado do anti-patterns.md e removido (passo 2.8)", {}, {
+  code: 0,
+  includes: ["exemplo comentado do anti-patterns.md removido"],
+});
+
+// --- `--only` valido continua a correr o que selecciona ------------------------
+test("`--only` valido corre so o seleccionado", {}, {
+  code: 0,
+  args: [`--only=${COMANDOS[0].split("/").pop().replace(".mjs", "")}`],
+  includes: ["1 verificacao(oes) verdes"],
+});
+
+console.log("");
+console.log(`  ${passed} passaram, ${falhas.length} falharam.`);
+console.log("");
+if (falhas.length) {
+  for (const { nome, out } of falhas) {
+    console.log(`--- output de "${nome}" ---`);
+    console.log(out);
+  }
+  console.log("  Ha testes do simulador a falhar.\n");
+  process.exit(1);
+}
+console.log("  Todos os testes do simulador passaram.\n");

--- a/.agent/scripts/tests-placeholders.mjs
+++ b/.agent/scripts/tests-placeholders.mjs
@@ -37,7 +37,7 @@ const bootstrapado = (dir) => {
       if (e.isDirectory()) anda(sub);
       // A lista de tipos espelha a Fase 2.1 do BOOTSTRAP. Faltava `.mdc` nas DUAS — o helper
       // e o bootstrap — o que deixava a regra do Cursor com o placeholder para sempre.
-      else if (/\.(md|mdc|mjs|json|yml|toml)$/.test(e.name) || e.name === "LICENSE" || e.name === "CODEOWNERS") {
+      else if (/\.(md|mdc|mjs|json|yml|toml)$/.test(e.name) || e.name === "LICENSE" || e.name === "CODEOWNERS" || sub.startsWith(".githooks/")) {
         const c = readF(dir, sub);
         const novo = c.replace(/\{\{(?!args\})[A-Z_]+\}\}/g, "VALOR");
         if (novo !== c) writeF(dir, sub, novo);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
         run: node .claude/hooks/tests/test-hooks.mjs
       - name: commit-msg hook — negative tests
         run: node .agent/scripts/test-commit-msg.mjs
+      - name: Simulador de projeto derivado — negative tests
+        run: node .agent/scripts/test-simulate-derived.mjs
       # A autoridade que o agente nao alcanca (AP4): se a superficie de teste encolher face a
       # base do PR, isto reprova. So em `pull_request` — e onde a base esta definida sem
       # ambiguidade (`github.event.before` vem a zeros no primeiro push de um branch).
@@ -188,6 +190,13 @@ jobs:
             echo "  Nenhuma mensagem no intervalo $base..HEAD — nao consegui verificar."
             exit 1
           fi
+      # A verificacao que testa a promessa do template: montar um projeto derivado e correr la
+      # tudo. Custa ~50s (copia o repo e recorre as suites), logo fica so em `pull_request` —
+      # e onde vale a pena e onde alguem le o resultado. Sem isto, a unica forma de saber que
+      # o template funciona num derivado era alguem lembrar-se de o experimentar.
+      - name: Projeto derivado — o template funciona depois do bootstrap
+        if: github.event_name == 'pull_request'
+        run: node .agent/scripts/simulate-derived.mjs
       - name: Test surface — nao enfraquecida desde a base do PR
         if: github.event_name == 'pull_request'
         # `HEAD^1` e nao `base.sha`: o checkout de um PR e o **merge ref**, cujo pai 1 e a

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ When you open a new AI session in any project using this template, the agent **a
     ├── tests-budgets.mjs       <- Series-1 guard tests (mirrors guards/budgets.mjs)
     ├── test-bundle-sizes.mjs   <- Negative tests for the bundle checker (no Next.js needed)
     ├── test-backlog.mjs        <- Negative tests for the backlog checker (synthetic fixture)
+    ├── simulate-derived.mjs    <- Builds a derived project and runs everything there
+    ├── test-simulate-derived.mjs<- Negative tests for it (minimal fixture repo, stubbed checkers)
     ├── mutation-sweep.mjs      <- Proves the suites assert: disables each warning, demands red
     └── test-mutation-sweep.mjs <- Negative tests for the sweep itself (fake checker + fake suite)
 


### PR DESCRIPTION
Fecha #32.

## O problema

Este repo e um **template**, e a promessa e "funciona no teu projeto derivado". Todas as suites corriam sobre o template **nu** — placeholders por substituir, rules do bootstrap por gerar. **Nada testava a promessa.**

## O que este PR acrescenta

`simulate-derived.mjs` monta um projeto derivado — copia, substitui placeholders, gera as rules da Fase 2.2, aplica o unico passo destrutivo mecanico da 2.8 — e corre la os nove verificadores. ~50s, no CI em `pull_request`.

## Encontrou um defeito no dia em que passou a existir

O `.githooks/commit-msg` tem `{{PROJECT_NAME}}` e **nao tem extensao** (o git exige o nome exacto do evento). Escapava a tres listas ao mesmo tempo: a Fase 2.1 do `BOOTSTRAP.md`, os alvos do Guard 13, e a substituicao do proprio simulador. **Num projeto derivado esse placeholder ficava la para sempre.**

Corrigido nas quatro pontas, mais uma entrada na matriz do `sync-docs.md` para o proximo ficheiro sem extensao nao repetir o percurso.

## Dois defeitos do proprio simulador, apanhados por controlo negativo

| Defeito | Porque importava |
|---|---|
| O `fatal` de "zero placeholders substituidos" era **inalcancavel** | este ficheiro tem um placeholder no cabecalho, logo a contagem nunca e zero. E o unico sitio onde chegaria a ser zero e um projeto **ja bootstrapado**, onde zero e o estado correcto — teria reprovado em **todos** os consumidores. E o `AP7` e o `AP3` no mesmo sitio |
| A varredura de sobras filtrava pelas **mesmas** extensoes que a substituicao | era cega ao caso que dizia apanhar. Passou a varrer tudo menos binarios — e foi assim que viu o `.githooks/commit-msg` |

Nenhum dos dois saiu de uma leitura. Sairam de desligar a correcao e exigir vermelho.

## Decisoes de desenho, que a issue deixava em aberto

- **Nome**: nao e `check-*` nem vive em `guards/`. A descoberta do `mutation-sweep` varre esses padroes e exige par em `PARES`; um alvo sem sitios de aviso proprios reprova la com `SINAL ERRADO` (medido). Este **orquestra** verificadores que ja tem par — o veredicto dele e o exit code deles.
- **Suite propria**: sim, para a logica dele (o que copia, substitui, gera, e recusar-se a dar OK sem ter medido). Fixture minima com stubs, logo corre em milissegundos.
- **CI**: a suite corre sempre; a simulacao a serio so em `pull_request`, que e onde alguem le o resultado.
- **Estados simulados**: "bootstrap concluido". O limite esta no cabecalho — **nao** executa a checklist passo a passo, logo uma instrucao errada noutro passo continua a precisar de alguem que a siga a mao. Reduz a janela; nao a fecha.

## Checklist

- [x] `check-doc-versions` e `check-backlog` — exit 0
- [x] Suites: 172 · 63 · 17 · **9** (nova) · 16 · 25 · 17 · 156, zero falhas
- [x] `simulate-derived.mjs` — exit 0, nove verificacoes verdes no derivado
- [x] 4 controlos negativos: desligar a varredura de sobras, repor a cegueira das extensoes, tirar o `fatal` de "nao mediu nada", tirar o `fatal` do BOOTSTRAP sem 2.2 — cada um acende exactamente o teste previsto
- [x] Registado no `scripts-guide.md`, `README.md`, `sync-docs.md` e `ci.yml`